### PR TITLE
seo: standardize "CCCSolutions" brand vs "CCC solutions" content

### DIFF
--- a/website/app/about/layout.tsx
+++ b/website/app/about/layout.tsx
@@ -1,13 +1,13 @@
 export const metadata = {
-  title: 'About CCC Solutions | Canadian Computing Competition Solution Repository Since 1996',
-  description: "Learn about CCC Solutions' 20+ year history providing comprehensive Canadian Computing Competition solutions. Founded at Milliken Mills High School in 2001, now serving 2,700+ students worldwide with 270+ CCC problem solutions.",
-  keywords: 'about CCC Solutions, Canadian Computing Competition history, CCC repository, Milliken Mills High School, Chris Robart, Don Smith, CCC contributors, competitive programming community',
+  title: 'About CCCSolutions | Canadian Computing Competition Solution Repository Since 1996',
+  description: "Learn about CCCSolutions' 20+ year history providing comprehensive Canadian Computing Competition solutions. Founded at Milliken Mills High School in 2001, now serving 2,700+ students worldwide with 270+ CCC problem solutions.",
+  keywords: 'about CCCSolutions, Canadian Computing Competition history, CCC repository, Milliken Mills High School, Chris Robart, Don Smith, CCC contributors, competitive programming community',
   robots: 'index, follow',
   alternates: {
     canonical: 'https://cccsolutions.ca/about',
   },
   openGraph: {
-    title: 'About CCC Solutions | 20+ Years of CCC Solutions',
+    title: 'About CCCSolutions | 20+ Years of CCC solutions',
     description: 'The story behind the most comprehensive Canadian Computing Competition solution repository, serving students since 2001.',
     url: 'https://cccsolutions.ca/about',
   },

--- a/website/app/contest/[contestYear]/[problemCode]/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/page.tsx
@@ -338,10 +338,10 @@ const Problem = () => {
             description: `Solution to ${
               problemInfo?.name || `CCC ${contestYear} ${problemCode.toUpperCase()}`
             } from the Canadian Computing Competition`,
-            author: { '@type': 'Organization', name: 'CCC Solutions Community' },
+            author: { '@type': 'Organization', name: 'CCCSolutions Community' },
             publisher: {
               '@type': 'Organization',
-              name: 'CCC Solutions',
+              name: 'CCCSolutions',
               logo: { '@type': 'ImageObject', url: 'https://cccsolutions.ca/icon.png' },
             },
             datePublished: `${contestYear}-02-01`,

--- a/website/app/forum/layout.tsx
+++ b/website/app/forum/layout.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
   title: 'CCC Forum | Ask Questions & Discuss Canadian Computing Competition Solutions',
-  description: 'Join the CCC Solutions community forum. Ask questions, share solutions, and discuss Canadian Computing Competition problems with fellow competitive programmers. Active community of 2,700+ students.',
+  description: 'Join the CCCSolutions community forum. Ask questions, share solutions, and discuss Canadian Computing Competition problems with fellow competitive programmers. Active community of 2,700+ students.',
   keywords: 'CCC forum, Canadian Computing Competition forum, CCC discussion, CCC help, competitive programming community, CCC questions, algorithm discussion, programming help',
   robots: 'index, follow',
   alternates: {

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -6,7 +6,7 @@ import Script from 'next/script';
 
 export const metadata = {
   metadataBase: new URL('https://cccsolutions.ca'),
-  title: 'CCC Solutions 2026 | Canadian Computing Competition Solutions (1996-2026)',
+  title: 'CCCSolutions 2026 | Canadian Computing Competition Solutions (1996-2026)',
   description: 'Master the Canadian Computing Competition with 270+ detailed solutions in C++, Python & Java. Complete CCC solutions from 1996-2026 with test cases, multiple approaches & explanations. Prepare for University of Waterloo CCC.',
   keywords: 'CCC, Canadian Computing Competition, CCC solutions, CCC 2026, CCC 2025, CCC 2024, University of Waterloo, Waterloo CCC, CEMC, competitive programming, CCC preparation, CCC past problems, CCC contest, CCC test cases, programming contest Canada, algorithm practice, coding competition, CCC Senior, CCC Junior, s1 s2 s3 s4 s5, j1 j2 j3 j4 j5, graph theory, dynamic programming, data structures',
   authors: [{ name: 'CCCSolutions Community' }],
@@ -17,13 +17,13 @@ export const metadata = {
   openGraph: {
     type: 'website',
     url: 'https://cccsolutions.ca',
-    title: 'CCC Solutions 2026 | Canadian Computing Competition Solutions',
+    title: 'CCCSolutions 2026 | Canadian Computing Competition Solutions',
     description: 'Master the Canadian Computing Competition with 270+ detailed solutions in C++, Python & Java. Complete CCC solutions from 1996-2026 with test cases and explanations.',
-    siteName: 'CCC Solutions',
+    siteName: 'CCCSolutions',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'CCC Solutions 2026 | Canadian Computing Competition Solutions',
+    title: 'CCCSolutions 2026 | Canadian Computing Competition Solutions',
     description: 'Master the Canadian Computing Competition with 270+ detailed solutions in C++, Python & Java from 1996-2026.',
   },
   other: {
@@ -50,8 +50,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "EducationalOrganization",
-              "name": "CCC Solutions",
-              "alternateName": ["Canadian Computing Competition Solutions", "CCCSolutions"],
+              "name": "CCCSolutions",
+              "alternateName": ["Canadian Computing Competition Solutions", "CCC Solutions"],
               "url": "https://cccsolutions.ca",
               "logo": "https://cccsolutions.ca/icon.png",
               "description": "The most comprehensive Canadian Computing Competition solution repository with 270+ solutions from 1996 to 2026",
@@ -73,7 +73,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: JSON.stringify({
               "@context": "https://schema.org",
               "@type": "WebSite",
-              "name": "CCC Solutions",
+              "name": "CCCSolutions",
               "url": "https://cccsolutions.ca",
               "description": "Complete Canadian Computing Competition solution repository from 1996-2026",
               "potentialAction": {

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -159,7 +159,7 @@ const Home = async () => {
                   </div>
                   <div>
                       <p className="text-4xl md:text-5xl font-semibold text-brand">{stats.numSolutions}</p>
-                      <p className="mt-1 text-base text-foreground-light">CCC Solutions</p>
+                      <p className="mt-1 text-base text-foreground-light">CCC solutions</p>
                   </div>
                   <div>
                       <p className="text-4xl md:text-5xl font-semibold text-brand">{stats.history}</p>

--- a/website/app/solutions/layout.tsx
+++ b/website/app/solutions/layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const metadata = {
-  title: 'All CCC Solutions (1996-2026) | Browse 270+ Canadian Computing Competition Problems',
+  title: 'All CCC solutions (1996-2026) | Browse 270+ Canadian Computing Competition Problems',
   description: 'Browse 270+ Canadian Computing Competition solutions from 1996-2026. Filter by year, difficulty (Easy to Wicked), or topic (graph theory, DP, greedy). Solutions in C++, Python & Java with test cases.',
   keywords: 'CCC solutions, Canadian Computing Competition problems, CCC all years, CCC 1996-2026, CCC past contests, CCC problem list, graph theory CCC, dynamic programming CCC, CCC difficulty, CCC Junior problems, CCC Senior problems, competitive programming solutions',
   robots: 'index, follow, max-image-preview:large',
@@ -9,7 +9,7 @@ export const metadata = {
     canonical: 'https://cccsolutions.ca/solutions',
   },
   openGraph: {
-    title: 'All CCC Solutions (1996-2026) | 270+ Problems',
+    title: 'All CCC solutions (1996-2026) | 270+ Problems',
     description: 'Browse all Canadian Computing Competition solutions. Filter by year, difficulty, or algorithm topic.',
     url: 'https://cccsolutions.ca/solutions',
   },

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,4 +1,4 @@
-# CCC Solutions - Canadian Computing Competition Solution Repository
+# CCCSolutions - Canadian Computing Competition Solution Repository
 
 > The most comprehensive Canadian Computing Competition (CCC) solution repository with 270+ solutions from 1996-2025
 
@@ -6,7 +6,7 @@
 - Home: https://cccsolutions.ca
 - All Solutions: https://cccsolutions.ca/solutions
 - Forum: https://cccsolutions.ca/forum
-- GitHub: https://github.com/Tankman61/CCCSolutions
+- GitHub: https://github.com/CCCSolutions/CCCSolutions
 
 ## What We Offer
 CCCSolutions is the definitive resource for Canadian Computing Competition preparation, featuring:
@@ -60,10 +60,10 @@ Greedy algorithms, ad hoc problem solving, string processing, computational geom
 The Canadian Computing Competition (CCC) is an annual programming contest organized by the Centre for Education in Mathematics and Computing (CEMC) at the University of Waterloo. It's open to students across Canada and internationally, with Junior and Senior divisions.
 
 ## Contributing
-This is a community-driven project. Contributors include students from across Canada who have solved and shared their approaches to CCC problems. Visit our GitHub repository to contribute: https://github.com/Tankman61/CCCSolutions
+This is a community-driven project. Contributors include students from across Canada who have solved and shared their approaches to CCC problems. Visit our GitHub repository to contribute: https://github.com/CCCSolutions/CCCSolutions
 
 ## Contact & Community
-- GitHub Issues: https://github.com/Tankman61/CCCSolutions/issues
+- GitHub Issues: https://github.com/CCCSolutions/CCCSolutions/issues
 - Forum: https://cccsolutions.ca/forum
 - Active community of 2,700+ users
 


### PR DESCRIPTION
## What

Consistent naming for SEO: the **brand/site/org** is always `CCCSolutions` (no space); references to the **actual solutions** stay `CCC solutions` (spaced, lowercase s).

### Brand → `CCCSolutions`
- `app/layout.tsx`: homepage `<title>`, OpenGraph + Twitter titles, `siteName`, JSON-LD Organization + WebSite `name`
- `app/about/layout.tsx`: title, description, keyword, OG title (1st half)
- `app/forum/layout.tsx`: "CCCSolutions community forum"
- `app/contest/[…]/page.tsx`: JSON-LD `author` + `publisher` names
- `public/llms.txt`: heading

### Kept/normalized as actual `CCC solutions`
- `app/solutions/layout.tsx`: "All CCC solutions (1996-2026)" (title + OG)
- `app/about/layout.tsx`: "20+ Years of CCC solutions"
- `app/page.tsx`: stat-card label (count of solutions)

### Also
- Structured-data `alternateName` now keeps `"CCC Solutions"` (spaced) as a search alias instead of duplicating the primary name.
- Fixed stale `github.com/Tankman61/CCCSolutions` links in `llms.txt` → `CCCSolutions/CCCSolutions`.