### PR TITLE
Switch site font to DM Sans, lighten heading/nav weights, About spacing + graph tail

### DIFF
--- a/website/app/about/page.tsx
+++ b/website/app/about/page.tsx
@@ -133,7 +133,7 @@ export default function About() {
           </div>
 
           <div className="lg:border-l lg:border-border-default lg:pl-14">
-            <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-3">A special thanks</h2>
+            <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6">A special thanks</h2>
             <p className="text-base text-foreground-light mb-10">
               The original solutions came from two Milliken Mills H.S. teachers who have been key in creating and maintaining this website. Enjoy your retirement!
             </p>

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -82,25 +82,24 @@ export default function ForumPage() {
 
   return (
     <div className="bg-background text-foreground">
-      {/* Header — always dark themed (white text on dark blue) regardless of global mode.
-          data-theme="dark" propagates to nested elements (e.g. SearchBar tokens),
-          but title/subtitle use explicit light colors so they're guaranteed white. */}
-      <div data-theme="dark" className="relative bg-blue-950 overflow-hidden border-b border-border-default">
+      {/* Header — home-hero treatment (theme-aware background + flickering grid), with the
+          grid dots in a clear blue (Tailwind blue-500). */}
+      <div className="relative bg-background overflow-hidden border-b border-border-default">
         <div aria-hidden className="absolute inset-0 z-0 pointer-events-none">
           <FlickeringGrid
             className="size-full"
             squareSize={4}
             gridGap={6}
-            color="hsl(239, 84%, 67%)"
-            maxOpacity={0.12}
+            color="#3b82f6"
+            maxOpacity={0.15}
             flickerChance={0.03}
           />
         </div>
         <SectionContainer size="large" className="relative z-10 pt-16 pb-12">
-          <h1 className="text-4xl md:text-5xl font-semibold tracking-tight text-white">
+          <h1 className="text-4xl md:text-5xl font-semibold tracking-tight text-foreground">
             Forum
           </h1>
-          <p className="mt-4 text-base md:text-lg text-white/75 max-w-2xl">
+          <p className="mt-4 text-base md:text-lg text-foreground-light max-w-2xl">
             Ask, search, or answer any question related to the CCC.
           </p>
         </SectionContainer>

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -163,7 +163,7 @@
 }
 
 @theme {
-  --font-sans: 'Lato', 'Roboto', 'Arial', sans-serif;
+  --font-sans: 'DM Sans', 'Lato', 'Roboto', 'Arial', sans-serif;
 
   --color-pastel-green: #c1e1c1;
   --color-pastel-blue: #c6e4ee;
@@ -239,7 +239,7 @@
 body {
     margin: 0;
     padding: 0;
-    font-family: 'Lato', sans-serif;
+    font-family: 'DM Sans', 'Lato', sans-serif;
     line-height: 1.6;
 }
 

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Fonts */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
 
         {/* Structured Data: Organization */}
         <script

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -155,15 +155,15 @@ const Home = async () => {
               <CardContent className="grid md:grid-cols-3 gap-8 py-12 px-8 border-none text-center">
                   <div>
                       <p className="text-4xl md:text-5xl font-semibold text-brand">{stats.activeUsers}</p>
-                      <p className="mt-1 text-base text-foreground-light">Active Users</p>
+                      <p className="mt-2 text-base text-foreground-light">Active Users</p>
                   </div>
                   <div>
                       <p className="text-4xl md:text-5xl font-semibold text-brand">{stats.numSolutions}</p>
-                      <p className="mt-1 text-base text-foreground-light">CCC solutions</p>
+                      <p className="mt-2 text-base text-foreground-light">CCC solutions</p>
                   </div>
                   <div>
                       <p className="text-4xl md:text-5xl font-semibold text-brand">{stats.history}</p>
-                      <p className="mt-1 text-base text-foreground-light">Providing Answers</p>
+                      <p className="mt-2 text-base text-foreground-light">Providing Answers</p>
                   </div>
               </CardContent>
           </Card>

--- a/website/app/solutions/page.tsx
+++ b/website/app/solutions/page.tsx
@@ -12,7 +12,7 @@ function SolutionsContent() {
     <div className="bg-background text-foreground">
       {/* Header — always dark themed (white text on dark blue) regardless of global mode.
           Title/subtitle use explicit light colors; data-theme="dark" propagates to SearchBar. */}
-      <div data-theme="dark" className="relative bg-blue-950 overflow-hidden border-b border-border-default">
+      <div data-theme="dark" className="relative overflow-hidden border-b border-border-default" style={{ backgroundColor: 'hsl(226 53% 26%)' }}>
         <div aria-hidden className="absolute inset-0 z-0 pointer-events-none">
           <FlickeringGrid
             className="size-full"

--- a/website/components/effects/GraphPattern.tsx
+++ b/website/components/effects/GraphPattern.tsx
@@ -117,6 +117,27 @@ function build() {
   for (let k = 0; k < path.length - 1; k++) {
     hiKeys.add(`${Math.min(path[k], path[k + 1])}-${Math.max(path[k], path[k + 1])}`);
   }
+  // Bold the existing edge that carries the path off-screen past the top-right
+  // endpoint, so the highlighted route reads as running beyond the frame
+  // (mirrors the source side at the bottom-left).
+  const prevIdx = path[path.length - 2];
+  const inDx = nodes[target].x - nodes[prevIdx].x;
+  const inDy = nodes[target].y - nodes[prevIdx].y;
+  let tail = -1;
+  let bestDot = -Infinity;
+  for (const v of adj[target]) {
+    const n = nodes[v];
+    if (n.x >= 0 && n.x <= VIEW_W && n.y >= 0 && n.y <= VIEW_H) continue; // must leave the frame
+    const dx = n.x - nodes[target].x;
+    const dy = n.y - nodes[target].y;
+    const dot = (inDx * dx + inDy * dy) / (Math.hypot(dx, dy) || 1);
+    if (dot > bestDot) {
+      bestDot = dot;
+      tail = v;
+    }
+  }
+  if (tail !== -1) hiKeys.add(`${Math.min(target, tail)}-${Math.max(target, tail)}`);
+
   for (const e of edges) e.hi = hiKeys.has(`${e.a}-${e.b}`);
 
   return { nodes, edges };

--- a/website/components/layout/Navbar.tsx
+++ b/website/components/layout/Navbar.tsx
@@ -50,7 +50,7 @@ const Navbar = () => {
                   key={item.name}
                   href={item.path}
                   className={`
-                    px-3 py-2 rounded-md text-lg font-medium
+                    px-3 py-2 rounded-md text-lg font-normal
                     relative
                     ${
                       pathname === item.path
@@ -98,7 +98,7 @@ const Navbar = () => {
                 key={item.name}
                 href={item.path}
                 className={`
-                  block px-3 py-2 rounded-md text-base font-medium
+                  block px-3 py-2 rounded-md text-base font-normal
                   relative overflow-hidden
                   ${
                     pathname === item.path

--- a/website/components/ui/card.tsx
+++ b/website/components/ui/card.tsx
@@ -24,7 +24,7 @@ export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDiv
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h3
-      className={cn('text-xl font-bold tracking-tight text-foreground', className)}
+      className={cn('text-2xl font-semibold tracking-tight text-foreground', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## What
- **Font:** Switch the site face from **Lato to DM Sans** (`--font-sans` + `body`, Lato kept as fallback). Lato only ships 400/700, so `font-semibold` was rounding up to full bold — DM Sans renders true mid-weights.
- **CardTitle:** `font-bold` → `font-semibold`, `text-xl` → `text-2xl`.
- **Navbar links:** `font-medium` → `font-normal`.
- **About:** `A special thanks` heading `mb-3` → `mb-6`.
- **Home stats card:** number→label gap `mt-1` → `mt-2`.
- **Graph hero:** bold the off-screen edge past the top-right endpoint.
- **Forum header:** drop the forced-dark navy block for the home-hero treatment (theme-aware `bg-background` + flickering grid) with blue (`#3b82f6`) dots.
- **Solutions header:** lighten the navy band from `blue-950` to `hsl(226 53% 26%)`.

Branched off `main`, no new dependencies.