### PR TITLE
ci: repo-wide GitHub Actions (CodeQL, Dependabot, Lighthouse, links, stale)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,42 @@
+name: Lighthouse
+
+# Informational only — never blocks merges (continue-on-error).
+# The site is built with `bun run build` and served with `next start` on :3000.
+# Maintainer note: if a production build needs env vars or a backend, add them
+# as repo secrets and wire them into the build/start steps below.
+
+on:
+  pull_request:
+    paths:
+      - "website/**"
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: website
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Start server
+        run: |
+          bun run start &
+          npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: http://localhost:3000
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,25 @@
+name: Links
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-retries 2
+            --accept 200,429
+            './**/*.md'
+          fail: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: pinned,security,good first issue
+          exempt-pr-labels: pinned,security,good first issue
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >-
+            Hi! This issue has been quiet for a while, so we've marked it stale.
+            No rush — just comment if it's still relevant and we'll keep it open.
+            Otherwise it'll close in 14 days.
+          stale-pr-message: >-
+            Hi! This PR has been quiet for a while, so we've marked it stale.
+            Push a commit or leave a comment when you're ready and we'll pick it
+            back up. Otherwise it'll close in 14 days.
+          close-issue-message: >-
+            Closing this for now since it's been inactive. Feel free to reopen
+            anytime — no hard feelings!
+          close-pr-message: >-
+            Closing this for now since it's been inactive. Reopen whenever you'd
+            like to continue. Thanks for contributing!

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# Cloudflare's community forum 403s all bots/crawlers, so valid links there fail the check.
+community.cloudflare.com


### PR DESCRIPTION
Adds five repo-wide GitHub Actions / configs. Each is independent and can be dropped from review without affecting the others.

- **CodeQL** (`.github/workflows/codeql.yml`) — `javascript-typescript` analysis on push to main, PRs, and a weekly schedule.
- **Dependabot** (`.github/dependabot.yml`) — weekly npm updates for `/backend` and `/website`, plus `github-actions` for `/`; minor/patch grouped to cut PR noise.
- **Lighthouse** (`.github/workflows/lighthouse.yml`) — builds the Next.js site with bun and runs Lighthouse on `website/**` PRs. **Non-blocking / informational** (`continue-on-error`, artifacts uploaded). See the comment in the file for the env/secret wiring a maintainer may need for a fuller build.
- **Link check** (`.github/workflows/links.yml`) — lychee over repo markdown on PRs + weekly; accepts 429 so rate-limits don't fail the build.
- **Stale bot** (`.github/workflows/stale.yml`) — daily; stale after 60d, close 14d later; exempts `pinned`/`security`/`good first issue`; friendly low-pressure messages.