### PR TITLE
ci: switch Dependabot to the bun ecosystem (keeps bun.lock in sync)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /backend
     schedule:
       interval: weekly
@@ -10,7 +10,7 @@ updates:
           - minor
           - patch
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /website
     schedule:
       interval: weekly


### PR DESCRIPTION
Dependabot was set to the `npm` ecosystem on a bun repo, so it bumped `package.json` but never updated `bun.lock`. Every dep PR then failed bun `--frozen-lockfile` installs (Cloudflare Workers builds + lighthouse). Switching `/backend` and `/website` to the `bun` ecosystem so lockfiles stay in sync. `github-actions` block unchanged.