### PR TITLE
feat: add forum preview mockup routes

### DIFF
--- a/website/app/forum/preview/logged-in/page.tsx
+++ b/website/app/forum/preview/logged-in/page.tsx
@@ -1,33 +1,346 @@
 'use client';
 
-import { MagnifyingGlassIcon, ChatBubbleIcon, ArrowUpIcon } from '@radix-ui/react-icons';
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { MagnifyingGlassIcon, PlusIcon } from '@radix-ui/react-icons';
 import { Button } from '../../../../components/ui/button';
 import { Card } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
+import { FlickeringGrid } from '../../../../components/effects/FlickeringGrid';
+import { AuthProvider, useAuth } from '../../../../components/auth/AuthProvider';
 
-export default function ForumPreviewLoggedIn() {
+// FIXME: this whole route is a visual mockup, not real feature code — mock
+// data below, no real forum backend wired up. Inspo for the real forum build.
+
+type YourPost = {
+  title: string;
+  kind: 'thread' | 'reply';
+  when: string;
+  replies?: number;
+  href: string;
+};
+
+const yourPostsMock: YourPost[] = [
+  {
+    title: '2024 S4: is the official editorial wrong about the complexity?',
+    kind: 'thread',
+    when: '6h ago',
+    replies: 4,
+    href: '/forum/preview/thread',
+  },
+  {
+    title: 'Re: Monotonic stack pattern: when do you actually reach for it?',
+    kind: 'reply',
+    when: '1d ago',
+    href: '/forum/preview/thread',
+  },
+  {
+    title: 'Re: How are you preparing for Senior 2026?',
+    kind: 'reply',
+    when: '3d ago',
+    href: '/forum/preview/thread',
+  },
+];
+
+// ─── Mock data ─────────────────────────────────────────────────────────────
+
+const popularTags = [
+  { tag: 'algorithms', count: 312 },
+  { tag: 'ccc-prep', count: 124 },
+  { tag: 'dp', count: 87 },
+  { tag: 'graphs', count: 64 },
+  { tag: 'greedy', count: 51 },
+  { tag: 'site-feedback', count: 41 },
+  { tag: 'strings', count: 39 },
+  { tag: 'segment-tree', count: 22 },
+  { tag: 'binary-search', count: 18 },
+  { tag: 'number-theory', count: 14 },
+];
+
+type Thread = {
+  id: string;
+  title: string;
+  excerpt: string;
+  tags: string[];
+  votes: number;
+  replies: number;
+  views: number;
+  isQuestion: boolean;
+  hasAccepted: boolean;
+  user: string;
+  rep: number;
+  when: string;
+  pinned?: boolean;
+};
+
+const threads: Thread[] = [
+  {
+    id: '1',
+    title: 'How are you preparing for Senior 2026? Looking for a pacing guide.',
+    excerpt:
+      "I'm aiming for S5 next year. Currently doing 2 problems a day from past contests but I'm not sure if I should be focusing more on USACO Gold or specific topics like graphs and DP. What's worked for you?",
+    tags: ['ccc-prep', 'study-plan'],
+    votes: 24,
+    replies: 9,
+    views: 412,
+    isQuestion: false,
+    hasAccepted: false,
+    user: 'tankman61',
+    rep: 8450,
+    when: '3h ago',
+    pinned: true,
+  },
+  {
+    id: '2',
+    title: '2024 S4: is the official editorial wrong about the complexity?',
+    excerpt:
+      'The editorial claims O(N log N) but the suggested approach uses a segment tree per node which would be O(N log² N). Am I missing something?',
+    tags: ['algorithms', 'segment-tree', 'complexity', '2024'],
+    votes: 18,
+    replies: 4,
+    views: 287,
+    isQuestion: true,
+    hasAccepted: false,
+    user: 'aetherwind',
+    rep: 1240,
+    when: '6h ago',
+  },
+  {
+    id: '3',
+    title: 'Monotonic stack pattern: when do you actually reach for it?',
+    excerpt:
+      "After solving 2023 S3 with a stack, I went back and noticed it's the same trick as histogram-largest-rectangle. Has anyone built a mental list of CCC-style problems where this pattern is the unlock?",
+    tags: ['algorithms', 'stack', 'patterns'],
+    votes: 31,
+    replies: 12,
+    views: 905,
+    isQuestion: false,
+    hasAccepted: false,
+    user: 'kshrestha',
+    rep: 3120,
+    when: '1d ago',
+  },
+  {
+    id: '4',
+    title: '1998 S5 Maze: adding a Python solution',
+    excerpt:
+      "Adding the Python solution that's been missing from this problem for years. BFS with a deque, ~80 lines. Walked through it in the editorial section but happy to discuss tradeoffs vs the C++ version.",
+    tags: ['algorithms', '1998', 'bfs', 'python'],
+    votes: 15,
+    replies: 3,
+    views: 198,
+    isQuestion: false,
+    hasAccepted: false,
+    user: 'minkyu',
+    rep: 540,
+    when: '1d ago',
+  },
+  {
+    id: '5',
+    title: 'Search keeps returning the wrong year ordering',
+    excerpt:
+      'When I filter for senior + year=2018, the 2008 problems also show up. Looks like a substring match instead of exact match on the year column.',
+    tags: ['site-feedback', 'bug', 'search'],
+    votes: 7,
+    replies: 1,
+    views: 64,
+    isQuestion: true,
+    hasAccepted: true,
+    user: 'sneha.k',
+    rep: 210,
+    when: '2d ago',
+  },
+  {
+    id: '6',
+    title: '2021 S2 Modern Art: WA on TC 7',
+    excerpt:
+      "I think there's a closed-form solution but I keep getting WA on TC 7. My current approach is parity counting on rows + columns. Anyone want to take a look?",
+    tags: ['algorithms', 'dp', '2021', 'parity'],
+    votes: 4,
+    replies: 0,
+    views: 86,
+    isQuestion: true,
+    hasAccepted: false,
+    user: 'leo.w',
+    rep: 80,
+    when: '9d ago',
+  },
+  {
+    id: '7',
+    title: 'Should we add a "verified on DMOJ" badge next to usernames in threads?',
+    excerpt:
+      "Right now the linked-DMOJ-handle thing only shows on profiles. It'd make threads way more credible if I could see at a glance whether the answerer has actually AC'd the problem they're discussing.",
+    tags: ['site-feedback', 'suggestion', 'profiles'],
+    votes: 22,
+    replies: 6,
+    views: 301,
+    isQuestion: false,
+    hasAccepted: false,
+    user: 'tankman61',
+    rep: 8450,
+    when: '4d ago',
+  },
+];
+
+// ─── Pills ─────────────────────────────────────────────────────────────────
+
+function TypePill({ isQuestion }: { isQuestion: boolean }) {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide text-foreground-light bg-surface-200 border border-border-default">
+      {isQuestion ? 'Question' : 'Discussion'}
+    </span>
+  );
+}
+
+function PinnedPill() {
+  return (
+    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900">
+      Pinned
+    </span>
+  );
+}
+
+function TagChip({ tag, small = false }: { tag: string; small?: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded text-foreground-light bg-surface-200 border border-border-default font-medium ${
+        small ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-[11px]'
+      }`}
+    >
+      #{tag}
+    </span>
+  );
+}
+
+// ─── Stats ─────────────────────────────────────────────────────────────────
+
+function StatLine({
+  value,
+  label,
+  boxed = false,
+}: {
+  value: number;
+  label: string;
+  boxed?: boolean;
+}) {
+  if (boxed) {
+    return (
+      <div className="inline-flex items-baseline gap-1 px-2 py-1 rounded border border-emerald-500 dark:border-emerald-600 text-emerald-700 dark:text-emerald-400">
+        <span className="text-sm font-semibold">{value.toLocaleString()}</span>
+        <span className="text-[11px]">{label}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="inline-flex items-baseline gap-1 px-2 py-1">
+      <span className="text-sm font-semibold text-foreground">{value.toLocaleString()}</span>
+      <span className="text-[11px] text-foreground-lighter">{label}</span>
+    </div>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────
+
+type SortKey = 'recent' | 'top' | 'unanswered';
+
+const sortLabels: Record<SortKey, string> = {
+  recent: 'Recent',
+  top: 'Top',
+  unanswered: 'Unanswered',
+};
+
+export default function ForumLoggedInPreview() {
+  return (
+    <AuthProvider>
+      <ForumLoggedInPreviewContent />
+    </AuthProvider>
+  );
+}
+
+// FIXME: real login-state read via AuthProvider — this stays fine once the
+// real forum lands, but everything it renders below is still mockup content.
+function ForumLoggedInPreviewContent() {
+  const [activeTags, setActiveTags] = useState<Set<string>>(new Set());
+  const [sort, setSort] = useState<SortKey>('recent');
+  const { state } = useAuth();
+
+  const toggleTag = (value: string) => {
+    setActiveTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+  };
+
+  const filtered = threads.filter((t) => {
+    if (activeTags.size > 0 && !Array.from(activeTags).every((tag) => t.tags.includes(tag)))
+      return false;
+    if (sort === 'unanswered' && t.replies > 0) return false;
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+    if (sort === 'top') return b.votes - a.votes;
+    return 0;
+  });
+
   return (
     <div className="bg-background text-foreground">
-      <SectionContainer size="large" className="py-16">
+      {/* Blue hero */}
+      <div
+        data-theme="dark"
+        className="relative bg-blue-950 overflow-hidden border-b border-border-default"
+      >
+        <div aria-hidden className="absolute inset-0 z-0 pointer-events-none">
+          <FlickeringGrid
+            className="size-full"
+            squareSize={4}
+            gridGap={6}
+            color="hsl(239, 84%, 67%)"
+            maxOpacity={0.12}
+            flickerChance={0.03}
+          />
+        </div>
+        <SectionContainer size="large" className="relative z-10 pt-14 pb-10">
+          <h1 className="text-4xl md:text-5xl font-semibold tracking-tight text-white">Forum</h1>
+          <p className="mt-3 text-base md:text-lg text-white/75 max-w-2xl">
+            Ask, search, or answer any question related to the CCC.
+          </p>
+        </SectionContainer>
+      </div>
+
+      <SectionContainer size="large" className="py-10">
         <div className="grid lg:grid-cols-[240px_1fr] gap-8">
-          {/* Sidebar — single placeholder category */}
+          {/* Sidebar */}
           <aside className="hidden lg:block">
-            <p className="text-[11px] uppercase tracking-wider text-foreground-lighter mb-3 px-3">
-              Categories
-            </p>
-            <nav className="flex flex-col gap-0.5">
-              <button
-                type="button"
-                className="flex items-center justify-between px-3 py-2 rounded-md text-sm bg-surface-200 text-foreground"
-              >
-                <span>Coming soon</span>
-              </button>
-            </nav>
+            <div className="flex flex-col gap-6">
+              <div>
+                <p className="text-[11px] uppercase tracking-wider text-foreground-lighter mb-2 px-2">
+                  Popular tags
+                </p>
+                <div className="flex flex-wrap gap-1.5 px-2">
+                  {popularTags.map((t) => (
+                    <TagButton
+                      key={t.tag}
+                      tag={t.tag}
+                      count={t.count}
+                      active={activeTags.has(t.tag)}
+                      onClick={() => toggleTag(t.tag)}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              {state === 'in' && <YourPostsBlock posts={yourPostsMock} />}
+              {state === 'out' && <SignUpBlock />}
+            </div>
           </aside>
 
           {/* Main */}
           <main className="min-w-0">
-            {/* Search bar */}
             <div className="relative mb-4">
               <MagnifyingGlassIcon
                 width="16"
@@ -36,55 +349,254 @@ export default function ForumPreviewLoggedIn() {
               />
               <input
                 type="text"
-                placeholder="Search…"
-                className="w-full h-10 pl-10 pr-4 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight"
+                placeholder="Search threads, comments, code..."
+                className="w-full h-10 pl-10 pr-16 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight"
               />
-              <span className="hidden md:inline-flex absolute right-3 top-1/2 -translate-y-1/2 items-center gap-1 px-1.5 py-0.5 rounded border border-border-default text-[10px] text-foreground-lighter">
+              <span className="hidden md:inline-flex absolute right-3 top-1/2 -translate-y-1/2 items-center gap-1 px-1.5 py-0.5 rounded border border-border-default text-[10px] text-foreground-lighter font-mono">
                 ⌘K
               </span>
             </div>
 
-            {/* Filter row */}
-            <div className="flex items-center justify-between mb-5 flex-wrap gap-3">
-              <div className="flex gap-1.5">
-                <Button type="primary" size="tiny">
-                  Recent
-                </Button>
+            <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+              <div className="flex gap-1 flex-wrap">
+                {(Object.keys(sortLabels) as SortKey[]).map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSort(key)}
+                    className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap ${
+                      sort === key
+                        ? 'bg-surface-200 text-foreground'
+                        : 'text-foreground-light hover:bg-surface-200/60 hover:text-foreground'
+                    }`}
+                  >
+                    {sortLabels[key]}
+                  </button>
+                ))}
               </div>
-              <Button type="primary" size="small">
-                + New thread
+              <Button
+                asChild
+                type="primary"
+                size="small"
+                className="whitespace-nowrap shrink-0 !pl-2.5"
+              >
+                <Link href="/forum/preview/new-thread" className="inline-flex items-center gap-1.5">
+                  <PlusIcon width={14} height={14} />
+                  New thread
+                </Link>
               </Button>
             </div>
 
-            {/* Single placeholder thread */}
-            <div className="flex flex-col gap-2">
-              <Card className="hover:bg-surface-200/40 transition-colors">
-                <div className="flex gap-4 px-5 py-4">
-                  <div className="flex flex-col items-center justify-start gap-3 pt-1 shrink-0 w-12">
-                    <div className="flex flex-col items-center text-foreground">
-                      <ArrowUpIcon width="14" height="14" className="text-foreground-lighter" />
-                      <span className="text-sm font-semibold">0</span>
-                    </div>
-                    <div className="flex flex-col items-center text-foreground-lighter">
-                      <ChatBubbleIcon width="14" height="14" />
-                      <span className="text-xs">0</span>
-                    </div>
-                  </div>
+            {activeTags.size > 0 && (
+              <div className="flex items-center gap-2 mb-3 text-xs text-foreground-light flex-wrap">
+                <span>Filters:</span>
+                {Array.from(activeTags).map((t) => (
+                  <button
+                    key={`t-${t}`}
+                    onClick={() => toggleTag(t)}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-border-default bg-surface-100 hover:border-border-strong"
+                  >
+                    #{t} <span className="text-foreground-lighter">×</span>
+                  </button>
+                ))}
+                <button
+                  onClick={() => setActiveTags(new Set())}
+                  className="text-foreground-lighter hover:text-foreground underline ml-1"
+                >
+                  Clear all
+                </button>
+              </div>
+            )}
 
-                  <div className="flex-1 min-w-0">
-                    <h3 className="text-base font-semibold text-foreground truncate mb-2">
-                      Coming soon coming soon
-                    </h3>
-                    <div className="flex items-center gap-2 text-xs text-foreground-lighter">
-                      <span>Coming soon</span>
-                    </div>
-                  </div>
-                </div>
-              </Card>
+            <Card>
+              <ul className="divide-y divide-border-default">
+                {sorted.length === 0 && (
+                  <li className="px-5 py-12 text-center text-sm text-foreground-light">
+                    No threads match your filters.
+                  </li>
+                )}
+                {sorted.map((t) => (
+                  <li key={t.id}>
+                    <Link
+                      href="/forum/preview/thread"
+                      className={`flex gap-5 px-5 py-4 hover:bg-surface-200/50 transition-colors border-l-2 ${
+                        t.pinned ? 'border-l-amber-500' : 'border-l-transparent'
+                      }`}
+                    >
+                      <div className="flex flex-col items-end gap-1 shrink-0 w-[110px]">
+                        <StatLine value={t.votes} label={t.votes === 1 ? 'vote' : 'votes'} />
+                        <StatLine
+                          value={t.replies}
+                          label={
+                            t.isQuestion
+                              ? t.replies === 1
+                                ? 'answer'
+                                : 'answers'
+                              : t.replies === 1
+                                ? 'reply'
+                                : 'replies'
+                          }
+                          boxed={t.isQuestion && t.hasAccepted}
+                        />
+                        <StatLine value={t.views} label={t.views === 1 ? 'view' : 'views'} />
+                      </div>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
+                          <TypePill isQuestion={t.isQuestion} />
+                          {t.pinned && <PinnedPill />}
+                        </div>
+                        <h3 className="text-base font-semibold text-foreground truncate">
+                          {t.title}
+                        </h3>
+                        <p className="text-xs text-foreground-light mt-1 line-clamp-2 leading-relaxed">
+                          {t.excerpt}
+                        </p>
+                        <div className="mt-2 flex items-center gap-2 flex-wrap text-[11px]">
+                          <div className="flex gap-1.5 flex-wrap">
+                            {t.tags.map((tag) => (
+                              <TagChip key={tag} tag={tag} small />
+                            ))}
+                          </div>
+                          <span className="text-foreground-lighter ml-auto whitespace-nowrap">
+                            @{t.user} · {t.rep.toLocaleString()} rep · {t.when}
+                          </span>
+                        </div>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+
+            <div className="flex items-center justify-between mt-5">
+              <span className="text-xs text-foreground-lighter">
+                Showing {sorted.length} of {threads.length} threads
+              </span>
+              <div className="flex gap-1.5">
+                <Button type="default" size="tiny" disabled>
+                  ← Prev
+                </Button>
+                <Button type="default" size="tiny">
+                  Next →
+                </Button>
+              </div>
             </div>
           </main>
         </div>
       </SectionContainer>
     </div>
+  );
+}
+
+function YourPostsBlock({ posts }: { posts: YourPost[] }) {
+  // Mock account stats
+  const account = {
+    username: 'aetherwind',
+    rep: 1240,
+    threads: 1,
+    replies: 2,
+  };
+
+  return (
+    <Card>
+      <div className="px-4 py-3 border-b border-border-default">
+        <div className="flex items-center gap-2.5">
+          <div className="size-8 rounded-full bg-brand-200 dark:bg-brand-200/30 border border-brand-300 dark:border-brand-300/40 flex items-center justify-center text-xs font-semibold text-brand shrink-0">
+            {account.username.slice(0, 2).toUpperCase()}
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-semibold text-foreground truncate">@{account.username}</p>
+            <p className="text-[11px] text-foreground-lighter">
+              {account.rep.toLocaleString()} rep · {account.threads}{' '}
+              {account.threads === 1 ? 'thread' : 'threads'} · {account.replies}{' '}
+              {account.replies === 1 ? 'reply' : 'replies'}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="px-4 py-3">
+        <p className="text-[11px] uppercase tracking-wider text-foreground-lighter mb-2.5">
+          Your posts
+        </p>
+        {posts.length === 0 ? (
+          <p className="text-xs text-foreground-light">
+            You haven&apos;t posted yet.{' '}
+            <Link
+              href="/forum/preview/new-thread"
+              className="text-brand hover:underline font-medium"
+            >
+              Start a thread →
+            </Link>
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2.5">
+            {posts.map((p, i) => (
+              <li key={i}>
+                <Link href={p.href} className="block group">
+                  <p className="text-xs font-medium text-foreground line-clamp-2 leading-snug group-hover:text-brand transition-colors">
+                    {p.title}
+                  </p>
+                  <p className="text-[11px] text-foreground-lighter mt-0.5">
+                    {p.kind === 'thread'
+                      ? `${p.replies ?? 0} ${p.replies === 1 ? 'reply' : 'replies'}`
+                      : 'reply'}{' '}
+                    · {p.when}
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function SignUpBlock() {
+  return (
+    <Card>
+      <div className="px-4 py-4">
+        <p className="text-sm font-semibold text-foreground mb-1.5">Join the conversation</p>
+        <p className="text-xs text-foreground-light leading-relaxed mb-3">
+          Post questions, answer threads, and pick up where you left off.
+        </p>
+        <div className="flex gap-2">
+          <Button asChild type="primary" size="tiny" className="flex-1">
+            <Link href="/signup">Sign up</Link>
+          </Button>
+          <Button asChild type="default" size="tiny" className="flex-1">
+            <Link href="/login">Log in</Link>
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function TagButton({
+  tag,
+  count,
+  active,
+  onClick,
+}: {
+  tag: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1 rounded text-[11px] font-medium border px-1.5 py-0.5 transition-colors ${
+        active
+          ? 'text-foreground bg-surface-200 border-border-strong'
+          : 'text-foreground-light bg-surface-100 border-border-default hover:border-border-strong hover:text-foreground'
+      }`}
+    >
+      #{tag}
+      <span className="text-foreground-lighter">{count}</span>
+    </button>
   );
 }

--- a/website/app/forum/preview/new-thread/page.tsx
+++ b/website/app/forum/preview/new-thread/page.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeftIcon, ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import { Button } from '../../../../components/ui/button';
+import { Card } from '../../../../components/ui/card';
+import { SectionContainer } from '../../../../components/ui/section-container';
+
+// FIXME: visual mockup, not real feature code — no backend wired up, form
+// doesn't submit anywhere. Inspo for the real "new thread" build.
+type ThreadType = 'question' | 'discussion';
+
+const placeholderByType: Record<ThreadType, string> = {
+  question:
+    'Be specific. Include what you tried, what you expected, and what actually happened.\n\nMarkdown + code blocks (```) + math ($...$) supported.',
+  discussion: 'What do you want to talk about? Open-ended is fine.',
+};
+
+const guideByType: Record<
+  ThreadType,
+  { intro: string; sections: { title: string; bullets: string[] }[] }
+> = {
+  question: {
+    intro: 'The community is here to help you with specific CCC, algorithm, or contest problems.',
+    sections: [
+      {
+        title: 'Summarize the problem',
+        bullets: [
+          'Lead with the problem code and what you are stuck on',
+          'Describe the expected vs actual output',
+          'Include any error messages or wrong-answer cases',
+        ],
+      },
+      {
+        title: "Describe what you've tried",
+        bullets: [
+          'Approach you took and where it broke',
+          'Specific test case numbers (e.g. WA on test case 7)',
+          'What you have already ruled out',
+        ],
+      },
+      {
+        title: 'Show some code',
+        bullets: [
+          'Trim to the relevant function — do not paste main()',
+          'Use triple backticks with a language hint: ```cpp',
+          'Include input the code was tested on',
+        ],
+      },
+    ],
+  },
+  discussion: {
+    intro:
+      'Discussions are open-ended. Frame the topic so others can jump in with their own takes.',
+    sections: [
+      {
+        title: 'Frame the topic',
+        bullets: [
+          'One sentence on what you want to talk about',
+          'Avoid vague titles like "DP question"',
+        ],
+      },
+      {
+        title: 'Give context',
+        bullets: [
+          'Link the problem, thread, or pattern that prompted this',
+          'Quote the editorial or comment you are reacting to',
+        ],
+      },
+      {
+        title: 'Invite specific responses',
+        bullets: [
+          'Open prompts get open answers',
+          'Ask for examples, comparisons, or opinions on a specific axis',
+        ],
+      },
+    ],
+  },
+};
+
+export default function NewThreadPreview() {
+  const [type, setType] = useState<ThreadType>('question');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [tags, setTags] = useState('');
+
+  const canSubmit = title.trim().length >= 15 && body.trim().length >= 30;
+
+  return (
+    <div className="bg-background text-foreground">
+      <SectionContainer size="large" className="py-8">
+        <Link
+          href="/forum/preview/logged-in"
+          className="inline-flex items-center gap-1.5 text-sm text-foreground-light hover:text-foreground mb-5"
+        >
+          <ArrowLeftIcon width="14" height="14" />
+          Back to forum
+        </Link>
+
+        <div className="grid lg:grid-cols-[1fr_360px] gap-10 items-start">
+          <div className="flex flex-col gap-6">
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+              Start a new thread
+            </h1>
+
+            {/* Type segmented control */}
+            <div className="inline-flex p-0.5 rounded-md border border-border-default bg-surface-100 self-start">
+              {(['question', 'discussion'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setType(t)}
+                  className={`px-4 py-1.5 rounded text-sm font-medium transition-colors ${
+                    type === t
+                      ? 'bg-brand-500 text-white'
+                      : 'text-foreground-light hover:text-foreground'
+                  }`}
+                >
+                  {t === 'question' ? 'Ask a question' : 'Start a discussion'}
+                </button>
+              ))}
+            </div>
+
+            <form className="flex flex-col gap-5">
+              <Field
+                label="Title"
+                hint={
+                  type === 'question'
+                    ? 'Be specific. Imagine you are asking another person. Min 15 characters.'
+                    : 'Frame the topic clearly. Min 15 characters.'
+                }
+              >
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={
+                    type === 'question'
+                      ? 'e.g. 2024 S4: why is the editorial complexity O(N log N) and not log²?'
+                      : 'e.g. Monotonic stack pattern: when do you reach for it?'
+                  }
+                  className="w-full h-10 px-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight"
+                />
+              </Field>
+
+              <Field
+                label="Body"
+                hint="Include all the information someone would need. Min 30 characters."
+              >
+                <textarea
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder={placeholderByType[type]}
+                  rows={12}
+                  className="w-full p-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight"
+                />
+              </Field>
+
+              <Field
+                label="Tags"
+                hint="Up to 5, comma-separated. Use existing tags where they exist. Start typing to see suggestions."
+              >
+                <input
+                  type="text"
+                  value={tags}
+                  onChange={(e) => setTags(e.target.value)}
+                  placeholder="e.g. dp, segment-tree, 2024"
+                  className="w-full h-10 px-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight"
+                />
+              </Field>
+
+              <div className="flex items-center justify-end gap-2 pt-2">
+                <Link
+                  href="/forum/preview/logged-in"
+                  className="px-3 py-2 text-sm text-foreground-light hover:text-foreground"
+                >
+                  Cancel
+                </Link>
+                <Button type="primary" size="small" disabled={!canSubmit}>
+                  Post {type === 'question' ? 'question' : 'discussion'}
+                </Button>
+              </div>
+            </form>
+          </div>
+
+          {/* Guide rail — SO-style accordion, aligned with H1 */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-[calc(var(--nav-h)+1.5rem)]">
+              <Guide type={type} />
+            </div>
+          </aside>
+        </div>
+      </SectionContainer>
+    </div>
+  );
+}
+
+function Guide({ type }: { type: ThreadType }) {
+  const guide = guideByType[type];
+  const [openIndex, setOpenIndex] = useState(0);
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-lg font-semibold text-foreground mb-2.5">
+        Draft your {type === 'question' ? 'question' : 'discussion'}
+      </h3>
+      <p className="text-sm text-foreground-light leading-relaxed mb-5">{guide.intro}</p>
+
+      <ol className="flex flex-col">
+        {guide.sections.map((section, i) => {
+          const isOpen = openIndex === i;
+          return (
+            <li key={i} className="border-t border-border-default first:border-t-0">
+              <button
+                type="button"
+                onClick={() => setOpenIndex(isOpen ? -1 : i)}
+                className="w-full flex items-center gap-3 py-3.5 text-left"
+              >
+                <span className="text-sm font-semibold text-brand shrink-0 w-5">{i + 1}.</span>
+                <span className="text-sm font-semibold text-foreground flex-1">
+                  {section.title}
+                </span>
+                {isOpen ? (
+                  <ChevronDownIcon
+                    width="16"
+                    height="16"
+                    className="text-foreground-lighter shrink-0"
+                  />
+                ) : (
+                  <ChevronRightIcon
+                    width="16"
+                    height="16"
+                    className="text-foreground-lighter shrink-0"
+                  />
+                )}
+              </button>
+              {isOpen && (
+                <ul className="pl-8 pb-4 space-y-1.5 list-disc list-outside marker:text-foreground-lighter">
+                  {section.bullets.map((b, bi) => (
+                    <li key={bi} className="text-sm text-foreground-light leading-relaxed ml-4">
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="mt-6 pt-5 border-t border-border-default">
+        <p className="text-sm font-semibold text-foreground mb-3">Helpful links</p>
+        <ul className="space-y-2 text-sm">
+          <li>
+            <Link href="#" className="text-brand hover:underline">
+              How to ask a good question
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="text-brand hover:underline">
+              Markdown + KaTeX cheatsheet
+            </Link>
+          </li>
+          <li>
+            <Link href="#" className="text-brand hover:underline">
+              Forum guidelines
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </Card>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-foreground mb-1">{label}</label>
+      {hint && <p className="text-[11px] text-foreground-light mb-2">{hint}</p>}
+      {children}
+    </div>
+  );
+}

--- a/website/app/forum/preview/thread/page.tsx
+++ b/website/app/forum/preview/thread/page.tsx
@@ -1,0 +1,554 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeftIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  CheckCircledIcon,
+  Share1Icon,
+  ExclamationTriangleIcon,
+  ChatBubbleIcon,
+} from '@radix-ui/react-icons';
+import { Button } from '../../../../components/ui/button';
+import { Card } from '../../../../components/ui/card';
+import { SectionContainer } from '../../../../components/ui/section-container';
+
+// FIXME: visual mockup, not real feature code — no backend wired up, votes/
+// replies below don't persist. Inspo for the real thread-view build.
+
+// ─── Mock thread data ──────────────────────────────────────────────────────
+
+const thread = {
+  title: '2024 S4: is the official editorial wrong about the complexity?',
+  isQuestion: true,
+  hasAccepted: false,
+  votes: 18,
+  views: 287,
+  asked: '6 hours ago',
+  lastActivity: '12 minutes ago',
+  body: `The editorial claims **O(N log N)** but the suggested approach uses a segment tree per node which would naively be O(N log² N).
+
+Specifically, the editorial walks through:
+
+1. Build a segment tree over the array
+2. For each query, perform a binary search inside the segment tree
+
+If both the outer iteration and the inner segment tree are log N, that should multiply, not add. Am I missing something? Is there an implicit fractional cascading / parallel binary search trick the editorial assumes?
+
+I tried both implementations on the official test data:
+- O(N log² N) implementation: 1.8s on TC 10
+- O(N log N) implementation (using fractional cascading): 0.4s on TC 10
+
+The TLE limit is 2s, so technically both pass, but the editorial is misleading.`,
+  tags: ['algorithms', 'segment-tree', 'complexity', '2024'],
+  author: { name: 'aetherwind', rep: 1240 },
+};
+
+type SubReply = {
+  id: string;
+  votes: number;
+  body: string;
+  author: { name: string; rep: number };
+  when: string;
+};
+
+type Answer = {
+  id: string;
+  votes: number;
+  accepted: boolean;
+  body: string;
+  author: { name: string; rep: number };
+  when: string;
+  subReplies: SubReply[];
+};
+
+const answers: Answer[] = [
+  {
+    id: 'a1',
+    votes: 12,
+    accepted: false,
+    body: `You're right that the *naive* implementation is O(N log² N). The editorial is being loose with notation.
+
+The trick is that the inner binary search shares structure with the outer iteration. If you precompute prefix/suffix arrays, you can amortize the inner search to O(1) per outer step, bringing the total to O(N log N).
+
+Look at the reference C++ solution at lines 47–63 — there's a \`pre[]\` and \`suf[]\` array being built before the main loop. That's the optimization the editorial doesn't explain.`,
+    author: { name: 'kshrestha', rep: 3120 },
+    when: '4h ago',
+    subReplies: [
+      {
+        id: 'a1-r1',
+        votes: 3,
+        body: 'Got it, that pre[]/suf[] trick is exactly what I missed. Going to file an issue against the editorial to clarify.',
+        author: { name: 'aetherwind', rep: 1240 },
+        when: '3h ago',
+      },
+      {
+        id: 'a1-r2',
+        votes: 1,
+        body: 'Same trick shows up in 2019 S5 if anyone wants more practice.',
+        author: { name: 'minkyu', rep: 540 },
+        when: '2h ago',
+      },
+    ],
+  },
+  {
+    id: 'a2',
+    votes: 5,
+    accepted: false,
+    body: `Adding to @kshrestha's answer — the unstated assumption is that the array values are bounded (≤ 10^6 in this problem). That's what enables the prefix-array trick. If values were unbounded, the editorial's claim genuinely would be wrong.
+
+Worth filing an issue against the editorial to add a sentence about this. The complexity claim isn't wrong, just under-specified.`,
+    author: { name: 'minkyu', rep: 540 },
+    when: '2h ago',
+    subReplies: [],
+  },
+];
+
+const otherUnanswered = [
+  { title: 'Approach for 2021 S2 Modern Art — keep getting WA on TC 7', age: '9 days' },
+  { title: '2018 S4 Wrong Answer — clarification on the input format', age: '4 days' },
+  { title: 'Why does my segment tree TLE on TC 12 of 2019 S5?', age: '1 day' },
+];
+
+// ─── Pills ─────────────────────────────────────────────────────────────────
+
+function TypePill({ isQuestion }: { isQuestion: boolean }) {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide text-foreground-light bg-surface-200 border border-border-default">
+      {isQuestion ? 'Question' : 'Discussion'}
+    </span>
+  );
+}
+
+function TagChip({ tag }: { tag: string }) {
+  return (
+    <Link
+      href="#"
+      className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium text-foreground-light bg-surface-200 border border-border-default hover:border-border-strong hover:text-foreground"
+    >
+      #{tag}
+    </Link>
+  );
+}
+
+// ─── Vote column (top-level) ───────────────────────────────────────────────
+
+function VoteColumn({ initial, accepted }: { initial: number; accepted?: boolean }) {
+  const [score, setScore] = useState(initial);
+  return (
+    <div className="flex flex-col items-center gap-0.5 shrink-0 w-10 pt-1">
+      <button
+        onClick={() => setScore((s) => s + 1)}
+        aria-label="Upvote"
+        className="text-foreground-lighter hover:text-brand transition-colors"
+      >
+        <ArrowUpIcon width="20" height="20" />
+      </button>
+      <span className="text-base font-semibold text-foreground">{score}</span>
+      <button
+        onClick={() => setScore((s) => s - 1)}
+        aria-label="Downvote"
+        className="text-foreground-lighter hover:text-destructive transition-colors"
+      >
+        <ArrowDownIcon width="20" height="20" />
+      </button>
+      {accepted !== undefined && (
+        <button
+          aria-label={accepted ? 'Accepted' : 'Mark as accepted'}
+          title={accepted ? 'Accepted answer' : 'Asker can mark this as the accepted answer'}
+          className={`mt-2 ${
+            accepted
+              ? 'text-emerald-600 dark:text-emerald-400'
+              : 'text-foreground-muted hover:text-emerald-600'
+          }`}
+        >
+          <CheckCircledIcon width="22" height="22" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Inline mini-vote (sub-replies) ────────────────────────────────────────
+
+function InlineVote({ initial }: { initial: number }) {
+  const [score, setScore] = useState(initial);
+  return (
+    <div className="inline-flex items-center gap-1 text-xs text-foreground-lighter">
+      <button
+        onClick={() => setScore((s) => s + 1)}
+        aria-label="Upvote"
+        className="hover:text-brand transition-colors"
+      >
+        <ArrowUpIcon width="13" height="13" />
+      </button>
+      <span className="font-medium text-foreground-light min-w-[1ch] text-center">{score}</span>
+      <button
+        onClick={() => setScore((s) => s - 1)}
+        aria-label="Downvote"
+        className="hover:text-destructive transition-colors"
+      >
+        <ArrowDownIcon width="13" height="13" />
+      </button>
+    </div>
+  );
+}
+
+// ─── Compact reply composer (collapsed → expanded) ─────────────────────────
+
+function ReplyComposer({
+  placeholder,
+  submitLabel,
+  minChars = 100,
+  forceOpen = false,
+  onCancel,
+  autoFocus = false,
+  compact = false,
+}: {
+  placeholder: string;
+  submitLabel: string;
+  minChars?: number;
+  forceOpen?: boolean;
+  onCancel?: () => void;
+  autoFocus?: boolean;
+  compact?: boolean;
+}) {
+  const [open, setOpen] = useState(forceOpen);
+  const [text, setText] = useState('');
+  const isOpen = open || forceOpen;
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="w-full h-10 px-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground-lighter text-left hover:border-border-stronger transition-colors"
+      >
+        {placeholder}
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-border-strong bg-surface-100 focus-within:border-brand-highlight transition-colors overflow-hidden">
+      <textarea
+        autoFocus={autoFocus || forceOpen}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={placeholder}
+        rows={compact ? 4 : 5}
+        className="w-full px-3 pt-3 bg-transparent text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none resize-y"
+      />
+      <div
+        className={`flex items-center justify-end gap-2 ${
+          compact ? 'px-3 pb-2.5 pt-1' : 'px-3 pb-3 pt-1.5'
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setText('');
+            setOpen(false);
+            onCancel?.();
+          }}
+          className="px-2.5 py-1 text-xs text-foreground-light hover:text-foreground"
+        >
+          Cancel
+        </button>
+        <Button type="primary" size="tiny" disabled={text.trim().length < minChars}>
+          {submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────
+
+type AnswerSort = 'top' | 'newest' | 'oldest';
+
+export default function ForumThreadPreview() {
+  const [sort, setSort] = useState<AnswerSort>('top');
+  const [openReplyId, setOpenReplyId] = useState<string | null>(null);
+
+  const sortedAnswers = [...answers].sort((a, b) => {
+    if (sort === 'top') return b.votes - a.votes;
+    if (sort === 'newest') return a.id < b.id ? 1 : -1;
+    return a.id < b.id ? -1 : 1;
+  });
+
+  return (
+    <div className="bg-background text-foreground">
+      <SectionContainer size="large" className="py-8">
+        {/* Breadcrumb */}
+        <div className="mb-5">
+          <Link
+            href="/forum/preview/logged-in"
+            className="inline-flex items-center gap-1.5 text-sm text-foreground-light hover:text-foreground"
+          >
+            <ArrowLeftIcon width="14" height="14" />
+            Back to forum
+          </Link>
+          <p className="text-xs text-foreground-lighter mt-3">
+            <Link href="/" className="hover:text-foreground">
+              Home
+            </Link>{' '}
+            /{' '}
+            <Link href="/forum/preview/logged-in" className="hover:text-foreground">
+              Forum
+            </Link>
+          </p>
+        </div>
+
+        {/* Title block */}
+        <div className="mb-6">
+          <div className="flex items-center gap-1.5 mb-2">
+            <TypePill isQuestion={thread.isQuestion} />
+          </div>
+          <h1 className="text-2xl md:text-3xl font-semibold tracking-tight text-foreground">
+            {thread.title}
+          </h1>
+          <div className="mt-2 flex items-center gap-3 text-xs text-foreground-lighter flex-wrap">
+            <span>
+              Asked <span className="text-foreground-light">{thread.asked}</span>
+            </span>
+            <span>·</span>
+            <span>
+              Active <span className="text-foreground-light">{thread.lastActivity}</span>
+            </span>
+            <span>·</span>
+            <span>
+              {thread.views} {thread.views === 1 ? 'view' : 'views'}
+            </span>
+          </div>
+        </div>
+
+        {/* Two-column layout */}
+        <div className="grid lg:grid-cols-[1fr_280px] gap-8">
+          <main className="min-w-0 flex flex-col gap-6">
+            {/* Question body */}
+            <Card>
+              <div className="flex gap-5 px-5 py-5">
+                <VoteColumn initial={thread.votes} />
+                <div className="flex-1 min-w-0">
+                  <div className="text-foreground-light">
+                    {thread.body.split('\n\n').map((para, i) => (
+                      <p key={i} className="mb-3 leading-relaxed whitespace-pre-wrap">
+                        {para}
+                      </p>
+                    ))}
+                  </div>
+                  <div className="mt-4 flex items-center gap-1.5 flex-wrap">
+                    {thread.tags.map((tag) => (
+                      <TagChip key={tag} tag={tag} />
+                    ))}
+                  </div>
+                  <div className="mt-4 pt-4 border-t border-border-default flex items-center justify-between flex-wrap gap-3">
+                    <div className="flex gap-3 text-xs">
+                      <button className="text-foreground-lighter hover:text-foreground inline-flex items-center gap-1">
+                        <Share1Icon width="12" height="12" /> Share
+                      </button>
+                      <button className="text-foreground-lighter hover:text-destructive inline-flex items-center gap-1">
+                        <ExclamationTriangleIcon width="12" height="12" /> Report
+                      </button>
+                    </div>
+                    <span className="text-xs text-foreground-lighter">
+                      asked by{' '}
+                      <Link href="#" className="text-brand hover:underline">
+                        @{thread.author.name}
+                      </Link>{' '}
+                      · {thread.author.rep.toLocaleString()} rep
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </Card>
+
+            {/* Top-level reply composer (collapsed by default) */}
+            <ReplyComposer
+              placeholder={thread.isQuestion ? 'Post your answer…' : 'Post your reply…'}
+              submitLabel={thread.isQuestion ? 'Post answer' : 'Post reply'}
+              minChars={100}
+            />
+
+            {/* Answers header + sort pills */}
+            <div className="flex items-center justify-between flex-wrap gap-2">
+              <h2 className="text-lg font-semibold text-foreground">
+                {answers.length}{' '}
+                {answers.length === 1
+                  ? thread.isQuestion
+                    ? 'Answer'
+                    : 'Reply'
+                  : thread.isQuestion
+                    ? 'Answers'
+                    : 'Replies'}
+              </h2>
+              <div className="flex gap-1">
+                {(['top', 'newest', 'oldest'] as const).map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setSort(key)}
+                    className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                      sort === key
+                        ? 'bg-surface-200 text-foreground'
+                        : 'text-foreground-light hover:bg-surface-200/60 hover:text-foreground'
+                    }`}
+                  >
+                    {key === 'top' ? 'Top' : key === 'newest' ? 'Newest' : 'Oldest'}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Top-level replies + sub-replies */}
+            {sortedAnswers.map((a) => (
+              <Card key={a.id}>
+                <div className="flex gap-5 px-5 py-5">
+                  <VoteColumn initial={a.votes} accepted={a.accepted} />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-foreground-light leading-relaxed whitespace-pre-wrap">
+                      {a.body}
+                    </div>
+                    <div className="mt-4 pt-3 border-t border-border-default flex items-center justify-between flex-wrap gap-3">
+                      <div className="flex gap-3 text-xs items-center">
+                        <button
+                          type="button"
+                          onClick={() => setOpenReplyId((prev) => (prev === a.id ? null : a.id))}
+                          className="text-foreground-lighter hover:text-foreground inline-flex items-center gap-1"
+                        >
+                          <ChatBubbleIcon width="12" height="12" /> Reply
+                        </button>
+                        <button className="text-foreground-lighter hover:text-foreground inline-flex items-center gap-1">
+                          <Share1Icon width="12" height="12" /> Share
+                        </button>
+                        <button className="text-foreground-lighter hover:text-destructive inline-flex items-center gap-1">
+                          <ExclamationTriangleIcon width="12" height="12" /> Report
+                        </button>
+                      </div>
+                      <span className="text-xs text-foreground-lighter">
+                        answered <span className="text-foreground-light">{a.when}</span> by{' '}
+                        <Link href="#" className="text-brand hover:underline">
+                          @{a.author.name}
+                        </Link>{' '}
+                        · {a.author.rep.toLocaleString()} rep
+                      </span>
+                    </div>
+
+                    {/* Sub-replies (1-deep, Reddit-style indent) */}
+                    {(a.subReplies.length > 0 || openReplyId === a.id) && (
+                      <div className="mt-4 pl-4 border-l-2 border-border-default flex flex-col gap-4">
+                        {a.subReplies.map((sr) => (
+                          <SubReplyView key={sr.id} reply={sr} />
+                        ))}
+                        {openReplyId === a.id && (
+                          <div className="pt-1">
+                            <ReplyComposer
+                              placeholder={`Reply to @${a.author.name}…`}
+                              submitLabel="Post reply"
+                              minChars={10}
+                              forceOpen
+                              autoFocus
+                              compact
+                              onCancel={() => setOpenReplyId(null)}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </main>
+
+          {/* Right rail */}
+          <aside>
+            <div className="flex flex-col gap-6">
+              <Card>
+                <div className="px-4 py-3 border-b border-border-default">
+                  <p className="text-[11px] uppercase tracking-wider text-foreground-lighter">
+                    Thread info
+                  </p>
+                </div>
+                <dl className="px-4 py-3 text-xs space-y-2">
+                  <div className="flex justify-between">
+                    <dt className="text-foreground-lighter">Asked</dt>
+                    <dd className="text-foreground-light">{thread.asked}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-foreground-lighter">Last activity</dt>
+                    <dd className="text-foreground-light">{thread.lastActivity}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-foreground-lighter">Views</dt>
+                    <dd className="text-foreground-light">{thread.views}</dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-foreground-lighter">Score</dt>
+                    <dd className="text-foreground-light">{thread.votes}</dd>
+                  </div>
+                </dl>
+              </Card>
+
+              <Card>
+                <div className="px-4 py-3 border-b border-border-default">
+                  <p className="text-[11px] uppercase tracking-wider text-foreground-lighter">
+                    Other open in #segment-tree
+                  </p>
+                </div>
+                <ul className="divide-y divide-border-default">
+                  {otherUnanswered.map((u, i) => (
+                    <li key={i}>
+                      <Link
+                        href="#"
+                        className="block px-4 py-3 hover:bg-surface-200/50 transition-colors"
+                      >
+                        <p className="text-xs font-medium text-foreground line-clamp-2 leading-snug">
+                          {u.title}
+                        </p>
+                        <p className="text-[11px] text-foreground-lighter mt-1">
+                          unanswered · {u.age}
+                        </p>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+                <div className="px-4 py-2.5 border-t border-border-default">
+                  <Link
+                    href="/forum/preview/logged-in"
+                    className="text-[11px] text-foreground-light hover:text-foreground"
+                  >
+                    See all open in #segment-tree →
+                  </Link>
+                </div>
+              </Card>
+            </div>
+          </aside>
+        </div>
+      </SectionContainer>
+    </div>
+  );
+}
+
+function SubReplyView({ reply }: { reply: SubReply }) {
+  return (
+    <div>
+      <p className="text-sm text-foreground-light leading-relaxed whitespace-pre-wrap">
+        {reply.body}
+      </p>
+      <div className="mt-2 flex items-center gap-3 text-[11px] flex-wrap">
+        <InlineVote initial={reply.votes} />
+        <span className="text-foreground-lighter">
+          <Link href="#" className="text-brand hover:underline">
+            @{reply.author.name}
+          </Link>{' '}
+          · {reply.author.rep.toLocaleString()} rep · {reply.when} ·{' '}
+          <button className="hover:text-destructive">Report</button>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/website/components/auth/AuthProvider.tsx
+++ b/website/components/auth/AuthProvider.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+// FIXME: built for the /forum/preview mockup routes only — reads the same
+// PocketBase session as Login.tsx, but isn't wired into the real forum yet.
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import PocketBase from 'pocketbase';
+
+const pb = new PocketBase('https://mmhs.pockethost.io');
+
+export type User = {
+  id: string;
+  username: string;
+  rep: number;
+};
+
+export type AuthState = 'pending' | 'in' | 'out';
+
+type AuthContextValue = {
+  state: AuthState;
+  user: User | null;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue>({
+  state: 'pending',
+  user: null,
+  logout: () => {},
+});
+
+function readUser(): User | null {
+  if (!pb.authStore.isValid) return null;
+  const m = pb.authStore.model;
+  if (!m) return null;
+  return {
+    id: m.id,
+    username: (m.username as string) || 'user',
+    rep: typeof m.rep === 'number' ? m.rep : 0,
+  };
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>('pending');
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const sync = () => {
+      const u = readUser();
+      setUser(u);
+      setState(u ? 'in' : 'out');
+    };
+    sync();
+    return pb.authStore.onChange(sync);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      state,
+      user,
+      logout: () => pb.authStore.clear(),
+    }),
+    [state, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}


### PR DESCRIPTION
<!--
Thanks for contributing! Lead with WHY: what was broken or missing, what you
changed, and why you went this way. Keep it specific, and feel free to delete
any sections that don't apply.
-->

## Description

Adds three unlinked `/forum/preview/*` routes (`new-thread`, `thread`, `logged-in`) showing what the rebuilt forum could look like. **These are visual mockups, not real feature code** — mock data, no backend wired up, nothing persists. Every file is marked with a `FIXME` comment saying so, so nobody mistakes this for done work. Real forum feature code (backend + real data) is a separate, later effort.

Not linked from any nav — reachable only if you know/guess the URL, same as the existing `/forum/preview` "coming soon" page already on `main`.

## Changes

- `app/forum/preview/new-thread/page.tsx` (new) — mock "create a thread" form.
- `app/forum/preview/thread/page.tsx` (new) — mock thread/reply view.
- `app/forum/preview/logged-in/page.tsx` — now wraps itself in `AuthProvider` so its logged-in/out conditional actually reflects a real session, instead of calling `useAuth()` with no provider ancestor (which silently pinned it to the unset default forever, so neither branch ever rendered).
- `components/auth/AuthProvider.tsx` (new) — reads the same PocketBase instance `Login.tsx` already talks to. No new backend dependency, read-only session check.

**Purely additive** — no existing route, layout, or shared component is touched. Confirmed via `git diff --stat main` that only these files changed.

## Testing

- `bun run typecheck`, `lint`, `format:check`, `build` all pass.
- Production build (`next build && next start`) hit all four `/forum/preview/*` routes — all 200, no console errors.

## Linked issues

Resolves #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] No `test_data` or other large files added to the repo
- [x] Docs/comments updated if behavior or APIs changed