### PR TITLE
fix: resolve npm EOVERRIDE conflict in website package.json

### DIFF
--- a/website/bun.lock
+++ b/website/bun.lock
@@ -36,10 +36,10 @@
     },
   },
   "overrides": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/website/package.json
+++ b/website/package.json
@@ -42,10 +42,10 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "$react",
+    "react-dom": "$react-dom",
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom"
   },
   "resolutions": {
     "react": "^19.0.0",


### PR DESCRIPTION
## Description

Every PR's `lighthouse` check has been failing with `npm error code EOVERRIDE`, unrelated to whatever the PR actually changes. Root cause: `react`/`react-dom`/`@types/react`/`@types/react-dom` are direct dependencies pinned to an exact version (`19.0.0`), and `overrides` also listed a separate (redundant) semver range (`^19.0.0`) for the same packages. npm 9+ rejects that as ambiguous — it can't tell which one should win.

Bun never enforced this (which is why `bun install` always worked fine), but `npx` — used by the `lighthouse` workflow's `wait-on` step — shells out through npm, which hit the conflict on every run.

## Changes

- `website/package.json`: point each `overrides` entry at its own dependency via npm's `"$name"` self-reference syntax, so there's one source of truth (the direct dependency version) instead of two copies that can drift.
- `website/bun.lock`: regenerated to match (bun resolves the `$` references to concrete versions in the lockfile).

## Testing

- `npx --yes wait-on --help` and `npm install --dry-run` in `website/` — both clean, no `EOVERRIDE`.
- `bun install` — no changes, `react`/`react-dom` still resolve to exact `19.0.0`.
- `bun run typecheck`, `lint`, `format:check`, `build` all pass.

## Linked issues

Resolves #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] No `test_data` or other large files added to the repo
- [x] Docs/comments updated if behavior or APIs changed