### PR TITLE
fix(website): post-R2-switchover display fixes

### DIFF
--- a/website/app/contest/[contestYear]/[problemCode]/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/page.tsx
@@ -129,7 +129,10 @@ const Problem = () => {
         const data: ListResponse = await res.json();
         if (cancelled) return;
 
-        const listTests = data.tests ?? [];
+        // Show sample cases first, then graded — each group by ascending n.
+        const listTests = [...(data.tests ?? [])].sort(
+          (a, b) => Number(b.sample) - Number(a.sample) || a.n - b.n
+        );
         setTests(listTests);
         if (listTests.length === 0) setTestCaseState('error');
 

--- a/website/app/contest/[contestYear]/[problemCode]/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/page.tsx
@@ -463,7 +463,7 @@ const Problem = () => {
             <div className="flex items-center p-3 border-b border-border-default overflow-x-auto">
               {tests.map((test, idx) => (
                 <button
-                  key={idx}
+                  key={`${test.sample ? 'sample' : 'case'}-${test.n}`}
                   onClick={() => handleTabClick(idx)}
                   className={`px-3 py-1 mr-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
                     activeTab === idx
@@ -471,7 +471,7 @@ const Problem = () => {
                       : 'bg-surface-200 text-foreground-light hover:bg-surface-300 hover:text-foreground'
                   }`}
                 >
-                  Case {idx + 1}
+                  {test.sample ? `Sample ${test.n}` : `Case ${test.n}`}
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Post-switchover display bugs (follow-up to #148)

### Fixed here
- **Test-case tab labels.** Tabs were labeled by array index (`Case {idx+1}`), so sample cases rendered as e.g. **Case 41 / Case 42** instead of **Sample 1 / Sample 2** (2017/s5 = 40 graded + 2 sample). Now labeled from each test's real `{sample, n}`. Fetch path was already correct.

### Tracked separately (R2 data relabel — NOT a frontend change)
- **Language chip wrong** (e.g. 2017/s5 C++ shows 'turing') and **solution download filenames wrong** (`solutions/1.t` for a C++ file) — both caused by mislabeled `ext` in R2, assigned by `stage-r2.js`'s buggy `detectLanguage` (checks Turing first with loose `put`/`get`/`:=` patterns). Audit of all ~300 solutions is in progress; the R2 relabel (copy-to-correct-key + delete-old) fixes both once the map is confirmed.

## Checks
`bun run typecheck` clean; label-only change.