### PR TITLE
feat(api): friendly download filenames via response-content-disposition

### DIFF
--- a/backend/src/r2/routes.ts
+++ b/backend/src/r2/routes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { AwsClient } from 'aws4fetch';
+import { z } from 'zod';
 import type { Bindings } from '../types';
 import { problemParamsSchema, fileSchema } from '../schemas';
 
@@ -72,6 +73,31 @@ function downloadName(file: string, year: string, code: string): string {
   return file.split('/').pop()!;
 }
 
+// Presign a short-lived R2 URL for one file, naming the download via
+// response-content-disposition. Shared by the single (GET) and batch (POST)
+// download endpoints so both stay on the same signing + filename logic.
+async function presignDownload(env: Bindings, year: string, code: string, file: string): Promise<string> {
+  const key = `contests/${year}/${code}/${file}`;
+
+  const client = new AwsClient({
+    accessKeyId: env.R2_ACCESS_KEY_ID,
+    secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+    service: 's3',
+    region: 'auto',
+  });
+
+  const endpoint = new URL(`https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${env.R2_BUCKET}/${key}`);
+  endpoint.searchParams.set('X-Amz-Expires', '300'); // presigned URL valid 5 minutes
+  endpoint.searchParams.set('response-content-disposition', `attachment; filename="${downloadName(file, year, code)}"`);
+
+  const signed = await client.sign(endpoint.toString(), {
+    method: 'GET',
+    aws: { signQuery: true }, // signature in the query string = presigned URL
+  });
+
+  return signed.url;
+}
+
 // R2 download endpoint: hand back a short-lived presigned URL so the browser
 // fetches the file straight from R2 (egress is free; the Worker never streams it).
 r2.get('/:year/:code/download', async (c) => {
@@ -79,28 +105,32 @@ r2.get('/:year/:code/download', async (c) => {
   const file = fileSchema.safeParse(c.req.query('file'));
   if (!params.success || !file.success)
     return c.text('Bad request: /contests/<year>/<code>/download?file=solutions/1.cpp', 400);
-  const key = `contests/${params.data.year}/${params.data.code}/${file.data}`;
 
-  const client = new AwsClient({
-    accessKeyId: c.env.R2_ACCESS_KEY_ID,
-    secretAccessKey: c.env.R2_SECRET_ACCESS_KEY,
-    service: 's3',
-    region: 'auto',
-  });
+  const url = await presignDownload(c.env, params.data.year, params.data.code, file.data);
+  return c.redirect(url, 302);
+});
 
-  const endpoint = new URL(`https://${c.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${c.env.R2_BUCKET}/${key}`);
-  endpoint.searchParams.set('X-Amz-Expires', '300'); // presigned URL valid 5 minutes
-  endpoint.searchParams.set(
-    'response-content-disposition',
-    `attachment; filename="${downloadName(file.data, params.data.year, params.data.code)}"`,
+// Batch download: one call → N presigned URLs, so a frontend zip doesn't fire
+// N separate (rate-limited) /download requests. Returns URLs, not bytes — the
+// browser fetches each straight from R2.
+const MAX_BATCH_FILES = 200;
+
+r2.post('/:year/:code/download', async (c) => {
+  const params = problemParamsSchema.safeParse({ year: c.req.param('year'), code: c.req.param('code') });
+  if (!params.success) return c.text('Bad request: POST /contests/<year>/<code>/download', 400);
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = z.object({ files: z.array(fileSchema).min(1).max(MAX_BATCH_FILES) }).safeParse(body);
+  if (!parsed.success) return c.text('Bad request: body must be { files: string[] } of valid file paths', 400);
+
+  const urls = await Promise.all(
+    parsed.data.files.map(async (file) => ({
+      file,
+      url: await presignDownload(c.env, params.data.year, params.data.code, file),
+    })),
   );
 
-  const signed = await client.sign(endpoint.toString(), {
-    method: 'GET',
-    aws: { signQuery: true }, // signature in the query string = presigned URL
-  });
-
-  return c.redirect(signed.url, 302);
+  return c.json({ urls });
 });
 
 export default r2;

--- a/backend/src/r2/routes.ts
+++ b/backend/src/r2/routes.ts
@@ -61,6 +61,17 @@ r2.get('/:year/:code/preview', async (c) => {
   return c.text(isSolution ? text : text.split('\n').slice(0, 50).join('\n'));
 });
 
+// Friendly download filename: samples read clearly, solutions carry year+code.
+function downloadName(file: string, year: string, code: string): string {
+  const sample = file.match(/^tests\/sample\/(\d+)\.(in|out)$/);
+  if (sample) return `sample${sample[1]}.${sample[2]}`;
+  const test = file.match(/^tests\/(\d+)\.(in|out)$/);
+  if (test) return `${test[1]}.${test[2]}`;
+  const sol = file.match(/^solutions\/(\d+)\.(\w+)$/);
+  if (sol) return `${year}_${code}_solution${sol[1]}.${sol[2]}`;
+  return file.split('/').pop()!;
+}
+
 // R2 download endpoint: hand back a short-lived presigned URL so the browser
 // fetches the file straight from R2 (egress is free; the Worker never streams it).
 r2.get('/:year/:code/download', async (c) => {
@@ -79,6 +90,10 @@ r2.get('/:year/:code/download', async (c) => {
 
   const endpoint = new URL(`https://${c.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${c.env.R2_BUCKET}/${key}`);
   endpoint.searchParams.set('X-Amz-Expires', '300'); // presigned URL valid 5 minutes
+  endpoint.searchParams.set(
+    'response-content-disposition',
+    `attachment; filename="${downloadName(file.data, params.data.year, params.data.code)}"`,
+  );
 
   const signed = await client.sign(endpoint.toString(), {
     method: 'GET',

--- a/backend/test/r2/routes.test.ts
+++ b/backend/test/r2/routes.test.ts
@@ -92,6 +92,17 @@ describe('GET /contests/:year/:code/download', () => {
     expect(loc).toContain('X-Amz-Signature=');
   });
 
+  it('names the download via response-content-disposition', async () => {
+    const env = { TESTCASES_SOLUTIONS_BUCKET: bucketReturning(null), ...R2_ENV };
+    const cd = async (file: string) => {
+      const res = await app.request(`/contests/2024/s1/download?file=${file}`, {}, env);
+      return decodeURIComponent(res.headers.get('location') ?? '');
+    };
+    expect(await cd('tests/sample/3.in')).toContain('filename="sample3.in"');
+    expect(await cd('tests/5.out')).toContain('filename="5.out"');
+    expect(await cd('solutions/1.py')).toContain('filename="2024_s1_solution1.py"');
+  });
+
   it('returns 400 for a bad file', async () => {
     const res = await app.request(
       '/contests/2024/s1/download?file=nope',

--- a/backend/test/r2/routes.test.ts
+++ b/backend/test/r2/routes.test.ts
@@ -113,6 +113,63 @@ describe('GET /contests/:year/:code/download', () => {
   });
 });
 
+describe('POST /contests/:year/:code/download (batch)', () => {
+  const env = { TESTCASES_SOLUTIONS_BUCKET: bucketReturning(null), ...R2_ENV };
+  const postFiles = (files: unknown) =>
+    app.request(
+      '/contests/2024/s1/download',
+      { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ files }) },
+      env,
+    );
+
+  it('returns a presigned URL per file, each named via response-content-disposition', async () => {
+    const res = await postFiles(['tests/sample/3.in', 'tests/5.out', 'solutions/1.py']);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { urls: { file: string; url: string }[] };
+    expect(body.urls.map((u) => u.file)).toEqual(['tests/sample/3.in', 'tests/5.out', 'solutions/1.py']);
+    const named = body.urls.map((u) => decodeURIComponent(u.url));
+    expect(named[0]).toContain('filename="sample3.in"');
+    expect(named[1]).toContain('filename="5.out"');
+    expect(named[2]).toContain('filename="2024_s1_solution1.py"');
+    for (const { url } of body.urls) {
+      expect(url).toContain('acct123.r2.cloudflarestorage.com');
+      expect(url).toContain('X-Amz-Signature=');
+    }
+  });
+
+  it('returns 400 when any file entry is invalid', async () => {
+    const res = await postFiles(['tests/1.in', '../../etc/passwd']);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an empty or oversized files array', async () => {
+    expect((await postFiles([])).status).toBe(400);
+    expect((await postFiles(Array.from({ length: 201 }, () => 'tests/1.in'))).status).toBe(400);
+  });
+
+  it('returns 400 for a malformed body', async () => {
+    const res = await app.request(
+      '/contests/2024/s1/download',
+      { method: 'POST', headers: { 'content-type': 'application/json' }, body: 'not json' },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a bad problem code', async () => {
+    const res = await app.request(
+      '/contests/2024/x9/download',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ files: ['tests/1.in'] }),
+      },
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
 describe('GET /contests/:year/:code/list', () => {
   it('classifies tests, samples, and solutions with sizes', async () => {
     const bucket = bucketListing([

--- a/website/app/contest/[contestYear]/[problemCode]/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/page.tsx
@@ -11,6 +11,7 @@ import {
   FileTextIcon,
   ArrowLeftIcon,
   DownloadIcon,
+  ExclamationTriangleIcon,
 } from '@radix-ui/react-icons';
 import { Card, CardContent } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
@@ -537,7 +538,10 @@ const Problem = () => {
                             <p className="mt-2 text-foreground-light">
                               Loading large test case ({formatSize(maxBytes)})…
                             </p>
-                            <p className="mt-1 text-sm text-warning">⚠️ This may take a moment</p>
+                            <p className="mt-1 flex items-center justify-center gap-1.5 text-sm text-warning">
+                              <ExclamationTriangleIcon width="13" height="13" />
+                              This may take a moment
+                            </p>
                           </div>
                         );
                       }
@@ -557,11 +561,17 @@ const Problem = () => {
                   {(getFileSizeWarning(activeTest.inputBytes) ||
                     getFileSizeWarning(activeTest.outputBytes)) && (
                     <div className="mb-4 p-3 bg-warning-200 border border-warning-400 rounded-md">
-                      <p className="text-sm text-warning-600">
-                        ⚠️{' '}
-                        {getFileSizeWarning(activeTest.inputBytes) ||
-                          getFileSizeWarning(activeTest.outputBytes)}{' '}
-                        — preview is truncated, use the Download button for the full file
+                      <p className="flex items-start gap-1.5 text-sm text-warning-600">
+                        <ExclamationTriangleIcon
+                          width="14"
+                          height="14"
+                          className="mt-0.5 shrink-0"
+                        />
+                        <span>
+                          {getFileSizeWarning(activeTest.inputBytes) ||
+                            getFileSizeWarning(activeTest.outputBytes)}{' '}
+                          — preview is truncated, use the Download button for the full file
+                        </span>
                       </p>
                     </div>
                   )}

--- a/website/app/contest/[contestYear]/[problemCode]/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/page.tsx
@@ -5,9 +5,16 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import { oneLight, oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { InfoCircledIcon, CodeIcon, FileTextIcon, ArrowLeftIcon } from '@radix-ui/react-icons';
+import {
+  InfoCircledIcon,
+  CodeIcon,
+  FileTextIcon,
+  ArrowLeftIcon,
+  DownloadIcon,
+} from '@radix-ui/react-icons';
 import { Card, CardContent } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
+import { DownloadDialog } from '../../../../components/contest/DownloadDialog';
 import { Problem as ProblemType, problems } from '../../../../constants';
 import dynamic from 'next/dynamic';
 
@@ -43,6 +50,10 @@ interface SolutionMeta {
 interface SolutionEntry {
   code: string;
   language: string;
+  // Present for real solutions (enables the per-card download); absent for the
+  // "no solution yet" placeholder entry.
+  n?: number;
+  ext?: string;
 }
 
 interface ListResponse {
@@ -70,6 +81,8 @@ const Problem = () => {
     'idle'
   );
   const [tests, setTests] = useState<TestMeta[]>([]);
+  const [solutionsMeta, setSolutionsMeta] = useState<SolutionMeta[]>([]);
+  const [downloadOpen, setDownloadOpen] = useState(false);
   const [problemInfo, setProblemInfo] = useState<ProblemType | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -134,6 +147,7 @@ const Problem = () => {
           (a, b) => Number(b.sample) - Number(a.sample) || a.n - b.n
         );
         setTests(listTests);
+        setSolutionsMeta([...(data.solutions ?? [])].sort((a, b) => a.n - b.n));
         if (listTests.length === 0) setTestCaseState('error');
 
         const solutionEntries = await Promise.all(
@@ -144,7 +158,7 @@ const Problem = () => {
               );
               if (!sres.ok) return null;
               const code = await sres.text();
-              return { code, language: extToLanguage(s.ext, code) };
+              return { code, language: extToLanguage(s.ext, code), n: s.n, ext: s.ext };
             } catch (error) {
               console.error(`Error fetching solution ${s.n}:`, error);
               return null;
@@ -153,7 +167,9 @@ const Problem = () => {
         );
         if (cancelled) return;
 
-        const validSolutions = solutionEntries.filter((e): e is SolutionEntry => e !== null);
+        const validSolutions = solutionEntries.filter(
+          (e): e is NonNullable<typeof e> => e !== null
+        );
         setSolutions(
           validSolutions.length > 0
             ? validSolutions
@@ -163,6 +179,7 @@ const Problem = () => {
         console.error('Error loading contest data:', error);
         if (cancelled) return;
         setTests([]);
+        setSolutionsMeta([]);
         setTestCaseState('error');
         setSolutions([{ code: SOLUTION_MISSING_MESSAGE, language: 'text' }]);
       } finally {
@@ -429,9 +446,21 @@ const Problem = () => {
                     <h3 className="font-medium text-foreground-light text-sm">
                       Solution {idx + 1}
                     </h3>
-                    <span className="text-xs font-medium text-foreground-lighter uppercase">
-                      {solution.language}
-                    </span>
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs font-medium text-foreground-lighter uppercase">
+                        {solution.language}
+                      </span>
+                      {solution.n !== undefined && solution.ext && (
+                        <a
+                          href={downloadUrl(`solutions/${solution.n}.${solution.ext}`)}
+                          className="text-foreground-lighter hover:text-brand transition-colors"
+                          aria-label={`Download solution ${idx + 1}`}
+                          title="Download solution"
+                        >
+                          <DownloadIcon width="15" height="15" />
+                        </a>
+                      )}
+                    </div>
                   </div>
                   <SyntaxHighlighter
                     language={solution.language}
@@ -456,9 +485,21 @@ const Problem = () => {
 
         {/* Test cases section */}
         <section>
-          <div className="flex items-center gap-2 mb-4">
-            <FileTextIcon width="18" height="18" className="text-brand" />
-            <h2 className="text-xl font-semibold text-foreground">Test cases</h2>
+          <div className="flex items-center justify-between gap-2 mb-4">
+            <div className="flex items-center gap-2">
+              <FileTextIcon width="18" height="18" className="text-brand" />
+              <h2 className="text-xl font-semibold text-foreground">Test cases</h2>
+            </div>
+            {(tests.length > 0 || solutionsMeta.length > 0) && (
+              <button
+                onClick={() => setDownloadOpen(true)}
+                className="inline-flex items-center gap-1.5 text-sm text-foreground-light hover:text-foreground transition-colors"
+                aria-label="Download test cases and solutions"
+              >
+                <DownloadIcon width="15" height="15" />
+                Download
+              </button>
+            )}
           </div>
 
           <Card>
@@ -520,7 +561,7 @@ const Problem = () => {
                         ⚠️{' '}
                         {getFileSizeWarning(activeTest.inputBytes) ||
                           getFileSizeWarning(activeTest.outputBytes)}{' '}
-                        — preview is truncated, use the download link for the full file
+                        — preview is truncated, use the Download button for the full file
                       </p>
                     </div>
                   )}
@@ -537,12 +578,6 @@ const Problem = () => {
                         readOnly
                         value={testCaseData.input || ''}
                       />
-                      <a
-                        href={downloadUrl(testFilePath(activeTest, 'in'))}
-                        className="inline-block mt-2 text-xs text-brand hover:underline"
-                      >
-                        Download full input
-                      </a>
                     </div>
                     <div>
                       <h3 className="font-medium text-foreground-light mb-2 text-sm">
@@ -556,12 +591,6 @@ const Problem = () => {
                         readOnly
                         value={testCaseData.output || ''}
                       />
-                      <a
-                        href={downloadUrl(testFilePath(activeTest, 'out'))}
-                        className="inline-block mt-2 text-xs text-brand hover:underline"
-                      >
-                        Download full output
-                      </a>
                     </div>
                   </div>
                 </div>
@@ -570,6 +599,16 @@ const Problem = () => {
           </Card>
         </section>
       </SectionContainer>
+
+      <DownloadDialog
+        open={downloadOpen}
+        onClose={() => setDownloadOpen(false)}
+        apiBase={API_BASE}
+        year={contestYear}
+        code={problemCode}
+        tests={tests}
+        solutions={solutionsMeta}
+      />
     </div>
   );
 };

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -10,6 +10,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "highlight.js": "^11.11.1",
+        "jszip": "^3.10.1",
         "katex": "^0.17.0",
         "lucide-react": "^1.22.0",
         "next": "^15.5.12",
@@ -650,6 +651,8 @@
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crossws": ["crossws@0.4.6", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg=="],
@@ -912,6 +915,8 @@
 
     "image-meta": ["image-meta@0.1.1", "", {}, "sha512-+oXiHwOEPr1IE5zY0tcBLED/CYcre15J4nwL50x3o0jxWqEkyjrusiKP3YSU+tr9fvJp33ZcP5Gpj2295g3aEw=="],
 
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -1004,7 +1009,7 @@
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
 
-    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1028,6 +1033,8 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
     "katex": ["katex@0.17.0", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
@@ -1037,6 +1044,8 @@
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1244,6 +1253,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "parchment": ["parchment@3.0.0", "", {}, "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -1286,6 +1297,8 @@
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
@@ -1324,7 +1337,7 @@
 
     "react-syntax-highlighter": ["react-syntax-highlighter@15.6.6", "", { "dependencies": { "@babel/runtime": "^7.3.1", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^3.6.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -1364,7 +1377,7 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
@@ -1379,6 +1392,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1430,7 +1445,7 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -1634,6 +1649,8 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "decode-named-character-reference/character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
@@ -1720,9 +1737,15 @@
 
     "rehype-katex/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
+    "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
     "stringify-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "unified/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1752,11 +1775,15 @@
 
     "vfile-message/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
     "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "bl/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "hast-util-from-dom/hastscript/hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
@@ -1778,6 +1805,14 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "bl/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "mdast-util-mdx-jsx/parse-entities/is-alphanumerical/is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "prebuild-install/tar-fs/tar-stream/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "prebuild-install/tar-fs/tar-stream/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
   }
 }

--- a/website/components/contest/DownloadDialog.tsx
+++ b/website/components/contest/DownloadDialog.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import JSZip from 'jszip';
-import { Cross2Icon, DownloadIcon } from '@radix-ui/react-icons';
+import { Cross2Icon, DownloadIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { Button } from '../ui/button';
 
 interface TestMeta {
@@ -28,10 +28,10 @@ interface DownloadItem {
   entryName: string;
 }
 
-// JSZip buffers every file in memory, so cap the total selected size to keep the
-// browser tab from OOM-ing. Egress is free; this is a memory guard, not a cost one.
-// Individual (direct) downloads are unbounded — they never touch this path.
-const ZIP_MAX_BYTES = 300 * 1024 * 1024;
+// JSZip buffers every file in memory, so a big selection can lag or crash the
+// tab. This isn't a hard limit (egress is free, and the zip still builds) — past
+// it we just warn. Individual (direct) downloads never touch this path.
+const ZIP_WARN_BYTES = 300 * 1024 * 1024;
 
 const formatSize = (bytes: number) =>
   bytes > 1024 * 1024
@@ -121,23 +121,52 @@ export function DownloadDialog({
 
   const downloadUrl = (file: string) => `${apiBase}/contests/${year}/${code}/download?file=${file}`;
 
-  const toggle = (file: string) =>
+  // Click-and-drag selection: mousedown on a row picks a mode (select vs deselect
+  // based on that row's current state) and applies it; dragging over more rows
+  // paints them the same. A plain click toggles a single row. Desktop only —
+  // touchscreens fall back to per-row taps. dragMode lives in a ref so the
+  // window mouseup listener and mouseenter handlers read it without re-rendering.
+  const dragMode = useRef<boolean | null>(null);
+
+  const applyDrag = (file: string, select: boolean) =>
     setSelected((prev) => {
+      if (prev.has(file) === select) return prev;
       const next = new Set(prev);
-      if (next.has(file)) next.delete(file);
-      else next.add(file);
+      if (select) next.add(file);
+      else next.delete(file);
       return next;
     });
+
+  const onRowMouseDown = (e: React.MouseEvent, file: string) => {
+    // Left button only, and never hijack the per-row download link.
+    if (e.button !== 0 || (e.target as HTMLElement).closest('a')) return;
+    e.preventDefault(); // don't start a text selection while dragging
+    const select = !selected.has(file);
+    dragMode.current = select;
+    applyDrag(file, select);
+  };
+
+  const onRowMouseEnter = (file: string) => {
+    if (dragMode.current !== null) applyDrag(file, dragMode.current);
+  };
+
+  useEffect(() => {
+    const end = () => {
+      dragMode.current = null;
+    };
+    window.addEventListener('mouseup', end);
+    return () => window.removeEventListener('mouseup', end);
+  }, []);
 
   const allSelected = items.length > 0 && selected.size === items.length;
   const toggleAll = () => setSelected(allSelected ? new Set() : new Set(items.map((i) => i.file)));
 
   const selectedItems = items.filter((i) => selected.has(i.file));
   const selectedBytes = selectedItems.reduce((sum, i) => sum + i.bytes, 0);
-  const overLimit = selectedBytes > ZIP_MAX_BYTES;
+  const largeSelection = selectedBytes > ZIP_WARN_BYTES;
 
   const downloadZip = async () => {
-    if (selectedItems.length === 0 || overLimit || zipping) return;
+    if (selectedItems.length === 0 || zipping) return;
     setZipping(true);
     setError(null);
     try {
@@ -220,7 +249,7 @@ export function DownloadDialog({
           </span>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-2 py-2">
+        <div className="flex-1 overflow-y-auto px-2 py-2 select-none">
           {items.length === 0 ? (
             <p className="px-3 py-6 text-center text-sm text-foreground-lighter">
               Nothing available to download.
@@ -229,13 +258,16 @@ export function DownloadDialog({
             items.map((item) => (
               <div
                 key={item.file}
-                className="flex items-center gap-3 px-3 py-1.5 rounded-md hover:bg-surface-200"
+                onMouseDown={(e) => onRowMouseDown(e, item.file)}
+                onMouseEnter={() => onRowMouseEnter(item.file)}
+                className="flex items-center gap-3 px-3 py-1.5 rounded-md cursor-pointer hover:bg-surface-200"
               >
                 <input
                   type="checkbox"
                   checked={selected.has(item.file)}
-                  onChange={() => toggle(item.file)}
-                  className="accent-brand-500"
+                  readOnly
+                  tabIndex={-1}
+                  className="accent-brand-500 pointer-events-none"
                   aria-label={item.label}
                 />
                 <span className="flex-1 text-sm text-foreground-light truncate">{item.label}</span>
@@ -255,10 +287,13 @@ export function DownloadDialog({
         </div>
 
         <div className="px-5 py-3 border-t border-border-default">
-          {overLimit && (
-            <p className="mb-2 text-xs text-warning-600">
-              ⚠️ Selection is {formatSize(selectedBytes)} — over the {formatSize(ZIP_MAX_BYTES)} zip
-              limit. Deselect some files, or download them individually.
+          {largeSelection && (
+            <p className="mb-2 flex items-start gap-1.5 text-xs text-warning-600">
+              <ExclamationTriangleIcon width="14" height="14" className="mt-0.5 shrink-0" />
+              <span>
+                Large selection ({formatSize(selectedBytes)}) — the zip is built in your browser and
+                may lag or freeze the tab.
+              </span>
             </p>
           )}
           {error && <p className="mb-2 text-xs text-destructive">{error}</p>}
@@ -267,7 +302,7 @@ export function DownloadDialog({
             size="small"
             block
             onClick={downloadZip}
-            disabled={selectedItems.length === 0 || overLimit || zipping}
+            disabled={selectedItems.length === 0 || zipping}
             iconLeft={<DownloadIcon width="15" height="15" />}
           >
             {zipping ? 'Building zip…' : 'Download selected (.zip)'}

--- a/website/components/contest/DownloadDialog.tsx
+++ b/website/components/contest/DownloadDialog.tsx
@@ -125,8 +125,11 @@ export function DownloadDialog({
   // based on that row's current state) and applies it; dragging over more rows
   // paints them the same. A plain click toggles a single row. Desktop only —
   // touchscreens fall back to per-row taps. dragMode lives in a ref so the
-  // window mouseup listener and mouseenter handlers read it without re-rendering.
+  // window listeners and the rAF loop read it without re-rendering.
   const dragMode = useRef<boolean | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const pointer = useRef({ x: 0, y: 0 });
+  const rafId = useRef<number | null>(null);
 
   const applyDrag = (file: string, select: boolean) =>
     setSelected((prev) => {
@@ -141,6 +144,7 @@ export function DownloadDialog({
     // Left button only, and never hijack the per-row download link.
     if (e.button !== 0 || (e.target as HTMLElement).closest('a')) return;
     e.preventDefault(); // don't start a text selection while dragging
+    pointer.current = { x: e.clientX, y: e.clientY };
     const select = !selected.has(file);
     dragMode.current = select;
     applyDrag(file, select);
@@ -150,12 +154,64 @@ export function DownloadDialog({
     if (dragMode.current !== null) applyDrag(file, dragMode.current);
   };
 
+  // Auto-scroll the list when a drag reaches its top/bottom edge, so off-screen
+  // rows scroll into view (and get painted) instead of being stuck out of reach.
   useEffect(() => {
+    const EDGE = 40; // px from an edge that triggers scrolling
+    const MAX_STEP = 16; // px per frame at the very edge (ramps with proximity)
+
+    const stopScroll = () => {
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+        rafId.current = null;
+      }
+    };
+
+    const step = () => {
+      const el = listRef.current;
+      if (!el || dragMode.current === null) {
+        rafId.current = null;
+        return;
+      }
+      const rect = el.getBoundingClientRect();
+      const { x, y } = pointer.current;
+      let delta = 0;
+      if (y < rect.top + EDGE) {
+        const p = Math.min(1, (rect.top + EDGE - y) / EDGE);
+        delta = -Math.ceil(p * MAX_STEP);
+      } else if (y > rect.bottom - EDGE) {
+        const p = Math.min(1, (y - (rect.bottom - EDGE)) / EDGE);
+        delta = Math.ceil(p * MAX_STEP);
+      }
+      if (delta === 0) {
+        rafId.current = null; // cursor left the edge zone — idle until it returns
+        return;
+      }
+      el.scrollTop += delta;
+      // Scrolling under a still cursor doesn't reliably fire mouseenter, so paint
+      // whichever row now sits under the pointer.
+      const row = document.elementFromPoint(x, y)?.closest<HTMLElement>('[data-file]');
+      if (row?.dataset.file) applyDrag(row.dataset.file, dragMode.current);
+      rafId.current = requestAnimationFrame(step);
+    };
+
+    const onMove = (e: MouseEvent) => {
+      if (dragMode.current === null) return;
+      pointer.current = { x: e.clientX, y: e.clientY };
+      if (rafId.current === null) rafId.current = requestAnimationFrame(step);
+    };
     const end = () => {
       dragMode.current = null;
+      stopScroll();
     };
+
+    window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', end);
-    return () => window.removeEventListener('mouseup', end);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', end);
+      stopScroll();
+    };
   }, []);
 
   const allSelected = items.length > 0 && selected.size === items.length;
@@ -249,7 +305,7 @@ export function DownloadDialog({
           </span>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-2 py-2 select-none">
+        <div ref={listRef} className="flex-1 overflow-y-auto px-2 py-2 select-none">
           {items.length === 0 ? (
             <p className="px-3 py-6 text-center text-sm text-foreground-lighter">
               Nothing available to download.
@@ -258,6 +314,7 @@ export function DownloadDialog({
             items.map((item) => (
               <div
                 key={item.file}
+                data-file={item.file}
                 onMouseDown={(e) => onRowMouseDown(e, item.file)}
                 onMouseEnter={() => onRowMouseEnter(item.file)}
                 className="flex items-center gap-3 px-3 py-1.5 rounded-md cursor-pointer hover:bg-surface-200"

--- a/website/components/contest/DownloadDialog.tsx
+++ b/website/components/contest/DownloadDialog.tsx
@@ -119,8 +119,7 @@ export function DownloadDialog({
     return () => document.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  const downloadUrl = (file: string) =>
-    `${apiBase}/contests/${year}/${code}/download?file=${file}`;
+  const downloadUrl = (file: string) => `${apiBase}/contests/${year}/${code}/download?file=${file}`;
 
   const toggle = (file: string) =>
     setSelected((prev) => {
@@ -131,8 +130,7 @@ export function DownloadDialog({
     });
 
   const allSelected = items.length > 0 && selected.size === items.length;
-  const toggleAll = () =>
-    setSelected(allSelected ? new Set() : new Set(items.map((i) => i.file)));
+  const toggleAll = () => setSelected(allSelected ? new Set() : new Set(items.map((i) => i.file)));
 
   const selectedItems = items.filter((i) => selected.has(i.file));
   const selectedBytes = selectedItems.reduce((sum, i) => sum + i.bytes, 0);

--- a/website/components/contest/DownloadDialog.tsx
+++ b/website/components/contest/DownloadDialog.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import JSZip from 'jszip';
+import { Cross2Icon, DownloadIcon } from '@radix-ui/react-icons';
+import { Button } from '../ui/button';
+
+interface TestMeta {
+  n: number;
+  sample: boolean;
+  inputBytes: number;
+  outputBytes: number;
+}
+
+interface SolutionMeta {
+  n: number;
+  ext: string;
+  bytes: number;
+}
+
+// One downloadable file: its R2-relative path, a readable label, byte size, and
+// the friendly name it gets inside the zip (mirrors the backend downloadName).
+interface DownloadItem {
+  file: string;
+  label: string;
+  bytes: number;
+  entryName: string;
+}
+
+// JSZip buffers every file in memory, so cap the total selected size to keep the
+// browser tab from OOM-ing. Egress is free; this is a memory guard, not a cost one.
+// Individual (direct) downloads are unbounded — they never touch this path.
+const ZIP_MAX_BYTES = 300 * 1024 * 1024;
+
+const formatSize = (bytes: number) =>
+  bytes > 1024 * 1024
+    ? `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+    : `${(bytes / 1024).toFixed(1)}KB`;
+
+function buildItems(tests: TestMeta[], solutions: SolutionMeta[]): DownloadItem[] {
+  const items: DownloadItem[] = [];
+  for (const t of tests) {
+    const dir = t.sample ? 'tests/sample' : 'tests';
+    const name = t.sample ? `Sample ${t.n}` : `Case ${t.n}`;
+    const prefix = t.sample ? `sample${t.n}` : `${t.n}`;
+    items.push({
+      file: `${dir}/${t.n}.in`,
+      label: `${name} · input`,
+      bytes: t.inputBytes,
+      entryName: `${prefix}.in`,
+    });
+    items.push({
+      file: `${dir}/${t.n}.out`,
+      label: `${name} · output`,
+      bytes: t.outputBytes,
+      entryName: `${prefix}.out`,
+    });
+  }
+  return items.concat(
+    solutions.map((s) => ({
+      file: `solutions/${s.n}.${s.ext}`,
+      label: `Solution ${s.n} (.${s.ext})`,
+      bytes: s.bytes,
+      entryName: '', // filled with year/code at render time
+    }))
+  );
+}
+
+interface DownloadDialogProps {
+  open: boolean;
+  onClose: () => void;
+  apiBase: string;
+  year: string;
+  code: string;
+  tests: TestMeta[];
+  solutions: SolutionMeta[];
+}
+
+export function DownloadDialog({
+  open,
+  onClose,
+  apiBase,
+  year,
+  code,
+  tests,
+  solutions,
+}: DownloadDialogProps) {
+  const items = useMemo(() => {
+    const built = buildItems(tests, solutions);
+    // Solutions carry the year/code in their zip entry name (matches backend).
+    for (const item of built) {
+      if (item.entryName === '') {
+        const m = item.file.match(/^solutions\/(\d+)\.(\w+)$/);
+        if (m) item.entryName = `${year}_${code}_solution${m[1]}.${m[2]}`;
+      }
+    }
+    return built;
+  }, [tests, solutions, year, code]);
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [zipping, setZipping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Nothing pre-selected; reset whenever the dialog re-opens or the file set changes.
+  useEffect(() => {
+    if (open) {
+      setSelected(new Set());
+      setError(null);
+    }
+  }, [open, items]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const downloadUrl = (file: string) =>
+    `${apiBase}/contests/${year}/${code}/download?file=${file}`;
+
+  const toggle = (file: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(file)) next.delete(file);
+      else next.add(file);
+      return next;
+    });
+
+  const allSelected = items.length > 0 && selected.size === items.length;
+  const toggleAll = () =>
+    setSelected(allSelected ? new Set() : new Set(items.map((i) => i.file)));
+
+  const selectedItems = items.filter((i) => selected.has(i.file));
+  const selectedBytes = selectedItems.reduce((sum, i) => sum + i.bytes, 0);
+  const overLimit = selectedBytes > ZIP_MAX_BYTES;
+
+  const downloadZip = async () => {
+    if (selectedItems.length === 0 || overLimit || zipping) return;
+    setZipping(true);
+    setError(null);
+    try {
+      // One batch call → N presigned URLs, avoiding N rate-limited /download hits.
+      const res = await fetch(`${apiBase}/contests/${year}/${code}/download`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ files: selectedItems.map((i) => i.file) }),
+      });
+      if (!res.ok) throw new Error(`batch ${res.status}`);
+      const { urls } = (await res.json()) as { urls: { file: string; url: string }[] };
+
+      const entryFor = (file: string) =>
+        items.find((i) => i.file === file)?.entryName ?? file.split('/').pop() ?? file;
+
+      const zip = new JSZip();
+      await Promise.all(
+        urls.map(async ({ file, url }) => {
+          const r = await fetch(url);
+          if (!r.ok) throw new Error(`fetch ${file} ${r.status}`);
+          zip.file(entryFor(file), await r.blob());
+        })
+      );
+
+      const blob = await zip.generateAsync({ type: 'blob' });
+      const href = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = href;
+      a.download = `${year}_${code}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(href);
+      onClose();
+    } catch (err) {
+      console.error('Error building zip:', err);
+      setError('Could not build the zip. Try individual downloads, or fewer files.');
+    } finally {
+      setZipping(false);
+    }
+  };
+
+  if (!open || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg max-h-[85vh] flex flex-col bg-surface-100 border border-border-default rounded-lg shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Download files"
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border-default">
+          <h3 className="text-sm font-semibold text-foreground">Download files</h3>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-foreground-lighter hover:text-foreground transition-colors"
+          >
+            <Cross2Icon width="16" height="16" />
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between px-5 py-2 border-b border-border-muted">
+          <label className="flex items-center gap-2 text-sm text-foreground-light cursor-pointer">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              className="accent-brand-500"
+            />
+            Select all
+          </label>
+          <span className="text-xs text-foreground-lighter">
+            {selected.size} selected · {formatSize(selectedBytes)}
+          </span>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-2 py-2">
+          {items.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-foreground-lighter">
+              Nothing available to download.
+            </p>
+          ) : (
+            items.map((item) => (
+              <div
+                key={item.file}
+                className="flex items-center gap-3 px-3 py-1.5 rounded-md hover:bg-surface-200"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(item.file)}
+                  onChange={() => toggle(item.file)}
+                  className="accent-brand-500"
+                  aria-label={item.label}
+                />
+                <span className="flex-1 text-sm text-foreground-light truncate">{item.label}</span>
+                <span className="text-xs text-foreground-lighter shrink-0">
+                  {formatSize(item.bytes)}
+                </span>
+                <a
+                  href={downloadUrl(item.file)}
+                  className="text-foreground-lighter hover:text-brand transition-colors shrink-0"
+                  aria-label={`Download ${item.label}`}
+                >
+                  <DownloadIcon width="15" height="15" />
+                </a>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="px-5 py-3 border-t border-border-default">
+          {overLimit && (
+            <p className="mb-2 text-xs text-warning-600">
+              ⚠️ Selection is {formatSize(selectedBytes)} — over the {formatSize(ZIP_MAX_BYTES)} zip
+              limit. Deselect some files, or download them individually.
+            </p>
+          )}
+          {error && <p className="mb-2 text-xs text-destructive">{error}</p>}
+          <Button
+            type="primary"
+            size="small"
+            block
+            onClick={downloadZip}
+            disabled={selectedItems.length === 0 || overLimit || zipping}
+            iconLeft={<DownloadIcon width="15" height="15" />}
+          >
+            {zipping ? 'Building zip…' : 'Download selected (.zip)'}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/website/constants.ts
+++ b/website/constants.ts
@@ -1833,7 +1833,14 @@ const problems: Problem[] = [
     hasSolution: true,
   },
 
-  // 2002 Senifalse	{ name: '2002 S2 - Fraction Action', difficulty: 'Easy', tags: ['GCD algorithm'], link: '/contest/2002/s2', hasSolution: true },
+  // 2002 Senior
+  {
+    name: '2002 S2 - Fraction Action',
+    difficulty: 'Easy',
+    tags: ['GCD algorithm'],
+    link: '/contest/2002/s2',
+    hasSolution: true,
+  },
   {
     name: '2002 S3 - Blindfold',
     difficulty: 'Normal',

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "highlight.js": "^11.11.1",
+    "jszip": "^3.10.1",
     "katex": "^0.17.0",
     "lucide-react": "^1.22.0",
     "next": "^15.5.12",


### PR DESCRIPTION
## Description

`/download` currently 302-redirects to a presigned R2 URL, and the browser names the saved file from the R2 key (e.g. a sample downloads as `1.in`, ambiguous with graded case 1). Because the download is **cross-origin** (frontend → api → r2.cloudflarestorage.com), the frontend `download="…"` attribute is **ignored** by the browser — only the server can name a cross-origin download, via `Content-Disposition`.

This presigns the URL with S3's `response-content-disposition` param so R2 serves the file with a friendly filename — **no R2 key rename needed** — and then builds the download UX on top of it: per-file download icons plus a batch **zip** picker on the contest page.

## Changes

**Backend (`backend/src/r2/routes.ts`)**
- Add `downloadName(file, year, code)` and set `response-content-disposition` on the presigned URL before signing (SigV4 query-signing covers the added param).
  - samples → `sample{n}.in/out` (clearer than `{n}`)
  - solutions → `{year}_{code}_solution{n}.{ext}`
  - graded → `{n}.in/out`
- Refactor the shared signing into a `presignDownload()` helper reused by both download paths.
- Add **`POST /contests/:year/:code/download`** taking `{ files: string[] }` and returning `{ urls: [{ file, url }] }` — one call yields N presigned URLs (validated with `fileSchema`, 400 on any invalid entry, capped at 200 files). Lets the frontend zip fetch bytes straight from R2 without firing N rate-limited `/download` requests. `GET …?file=…` → 302 is unchanged.

**Frontend (`website/`)**
- Download **icon** on each solution card → direct `GET /download?file=solutions/{n}.{ext}`.
- Replace the per-test "Download full input/output" links with a **Download** button on the test-cases card that opens a new `components/contest/DownloadDialog.tsx` popup: a scrollable, checkbox list of every case file (Sample N / Case N) + the solution(s), with **Select all**. Individual rows link straight to `GET /download`; **"Download selected (.zip)"** POSTs the batch endpoint, `fetch()`es each presigned URL from R2, and bundles them with **JSZip** (new `website` dep), naming entries to match `downloadName` (`sample{n}.in`, `{n}.in`, `{year}_{code}_solution{n}.{ext}`).
- **Zip size guard:** sums `inputBytes`/`outputBytes`/`bytes` from `/list` and disables the zip over a 300MB selection — a browser **memory** guard (JSZip buffers in RAM), not a cost one; egress is free and individual downloads stay unbounded. Nothing is pre-selected. Design/dark-mode preserved; icons from `@radix-ui/react-icons`.

## ⚠️ Required follow-up before zip works in prod — R2 bucket CORS

JSZip `fetch()`es file bytes directly off presigned `*.r2.cloudflarestorage.com` URLs, which is **cross-origin** from the frontend. The R2 bucket must allow the frontend origins in its **CORS policy** (dashboard/API setting — not in this repo):

- `http://localhost:3000`
- `https://cccsolutions.ca`
- `https://v2.cccsolutions.ca`

`AllowedMethods: [GET]` is enough (the batch/`/list`/`/preview` API calls are already handled by the Worker's own CORS). Until this is set, **the zip button will fail** on CORS — individual 302 downloads are navigations and do **not** need it, so they keep working.

## Testing

- Backend vitest: GET 302 `Location` carries `filename="sample3.in"` / `filename="5.out"` / `filename="2024_s1_solution1.py"`; POST batch returns a correctly-named presigned URL per file; invalid/empty/oversized/malformed bodies → 400. Full suite green, coverage ~98% (≥70% gate).
- `tsc`, `format`/`lint` pass in `backend/`; `bun run lint && bun run typecheck && bun run build` pass in `website/`.

## Linked issues

Refs #48

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over
- [x] `tsc`, lint, and tests pass locally
- [x] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style
- [x] No `test_data` or other large files added to the repo
- [x] Docs/comments updated if behavior or APIs changed
- [x] **R2 bucket CORS** configured for the frontend origins (dashboard — required before the zip download works in prod)
