### PR TITLE
fix(website): download a single selection raw, not as a 1-file zip

### DIFF
--- a/website/components/contest/DownloadDialog.tsx
+++ b/website/components/contest/DownloadDialog.tsx
@@ -219,10 +219,27 @@ export function DownloadDialog({
 
   const selectedItems = items.filter((i) => selected.has(i.file));
   const selectedBytes = selectedItems.reduce((sum, i) => sum + i.bytes, 0);
-  const largeSelection = selectedBytes > ZIP_WARN_BYTES;
+  // Only a 2+ selection builds a zip, so the browser-memory caution is scoped to that.
+  const largeSelection = selectedItems.length >= 2 && selectedBytes > ZIP_WARN_BYTES;
 
-  const downloadZip = async () => {
+  // Trigger a direct browser download of one file via the GET /download endpoint,
+  // which 302s to R2 with Content-Disposition. Same mechanism as the per-row link
+  // (no fetch/JSZip/CORS needed) — a single selection shouldn't become a 1-file zip.
+  const downloadSingle = (file: string) => {
+    const a = document.createElement('a');
+    a.href = downloadUrl(file);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    onClose();
+  };
+
+  const downloadSelected = async () => {
     if (selectedItems.length === 0 || zipping) return;
+    if (selectedItems.length === 1) {
+      downloadSingle(selectedItems[0].file);
+      return;
+    }
     setZipping(true);
     setError(null);
     try {
@@ -358,11 +375,15 @@ export function DownloadDialog({
             type="primary"
             size="small"
             block
-            onClick={downloadZip}
+            onClick={downloadSelected}
             disabled={selectedItems.length === 0 || zipping}
             iconLeft={<DownloadIcon width="15" height="15" />}
           >
-            {zipping ? 'Building zip…' : 'Download selected (.zip)'}
+            {zipping
+              ? 'Building zip…'
+              : selectedItems.length === 1
+                ? 'Download file'
+                : 'Download selected (.zip)'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Description

Follow-up to #156 (already merged). In the download picker, "Download selected (.zip)" built a zip even when a **single** file was selected — a 1-file zip is the wrong output; a lone selection should download the raw file.

#156 was already squash-merged before this fix was ready, so this is a small standalone PR against `main` rather than another commit on that (now-deleted) branch.

## Changes

- `website/components/contest/DownloadDialog.tsx`:
  - When exactly **one** item is selected, the button now triggers a **direct** `GET /download` (an `<a>` with `href = downloadUrl(file)` — the same 302-to-R2-with-`Content-Disposition` mechanism as the per-row link). No `fetch`, no JSZip, no CORS dependency for the single case.
  - The batch-POST + JSZip flow runs only for **2+** files (unchanged).
  - Button label reflects the count: `Download file` for one, `Download selected (.zip)` for 2+ (`Building zip…` while zipping); still disabled at zero.
  - The browser-memory "large selection" warning is now scoped to the 2+ (zip) case, since a single file downloads directly and never buffers in memory.

Drag-select, edge auto-scroll, Select-all, and the per-row download links are all unchanged.

## Testing

- `bun run typecheck`, `bun run lint` (clean bar the pre-existing `no-page-custom-font` warning in `layout.tsx`), and `bunx prettier --check .` all pass.

## Linked issues

Refs #48. Follows up #156.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] No `test_data` or other large files added to the repo
- [x] Docs/comments updated if behavior or APIs changed
