### PR TITLE
fix(website): unclip solutions search dropdown; deprecate past_contests + stage-r2

### DIFF
--- a/scripts/stage-r2.js
+++ b/scripts/stage-r2.js
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
+//
+// =====================================================================
+//  DEPRECATED — DO NOT USE
+// =====================================================================
+//  This staging script is unreliable: `detectLanguage` mislabels
+//  solutions (heuristic guessing of Turing/C++/Java/Python from source
+//  frequently picks the wrong language), so the staged `solutions/{n}.{ext}`
+//  files end up with incorrect extensions.
+//
+//  It is superseded by the /admin R2 upload endpoint, which is the
+//  supported way to get contest data into R2. This file is kept for
+//  reference only and is guarded so it cannot be run accidentally (see the
+//  early exit at the bottom). Remove the guard only if you knowingly need
+//  to inspect its behaviour.
+// =====================================================================
+//
 // Stage website/public/past_contests/ into ~/r2-staging/contests/ in the
 // renamed/normalized layout that R2 will hold.
 //
@@ -210,4 +226,13 @@ function main() {
   console.log(`output:   ${DST}`);
 }
 
+// DEPRECATED / DO NOT USE — guarded so it cannot be run accidentally.
+// Unreliable language detection; superseded by the /admin R2 upload endpoint.
+console.error(
+  'scripts/stage-r2.js is DEPRECATED and disabled (unreliable language detection).\n' +
+    'Use the /admin R2 upload endpoint instead. Kept for reference only.'
+);
+process.exit(1);
+
+// eslint-disable-next-line no-unreachable
 main();

--- a/website/app/solutions/page.tsx
+++ b/website/app/solutions/page.tsx
@@ -14,10 +14,12 @@ function SolutionsContent() {
           Title/subtitle use explicit light colors; data-theme="dark" propagates to SearchBar. */}
       <div
         data-theme="dark"
-        className="relative overflow-hidden border-b border-border-default"
+        className="relative border-b border-border-default"
         style={{ backgroundColor: 'hsl(228 50% 27%)' }}
       >
-        <div aria-hidden className="absolute inset-0 z-0 pointer-events-none">
+        {/* overflow-hidden lives on this grid wrapper (not the band) so the SearchBar
+            dropdown can overflow the band and overlay the table below without being clipped. */}
+        <div aria-hidden className="absolute inset-0 z-0 overflow-hidden pointer-events-none">
           <FlickeringGrid
             className="size-full"
             squareSize={4}

--- a/website/components/solutions/SolutionPreview.tsx
+++ b/website/components/solutions/SolutionPreview.tsx
@@ -16,7 +16,10 @@ const SyntaxHighlighter = dynamic(
 );
 
 // Real solutions for CCC 2025 S4 (Floor is Lava) — Insane / graph theory.
-// Pulled verbatim from public/past_contests/2025/s4/
+// Originally pulled verbatim from public/past_contests/2025/s4/.
+// DEPRECATED PATH: public/past_contests/ is deprecated and will be removed soon
+// (contest data now comes from R2 via the API). This code is inlined here, so it
+// has no runtime dependency on that directory — do not reintroduce one.
 type Solution = {
   language: 'Python' | 'C++';
   prismLang: 'python' | 'cpp';

--- a/website/public/past_contests/DEPRECATED.md
+++ b/website/public/past_contests/DEPRECATED.md
@@ -1,0 +1,17 @@
+# DEPRECATED: `public/past_contests/`
+
+**Status: deprecated. Scheduled for removal.**
+
+These static test-case and solution files are no longer used by the app. The
+site now serves every contest's problem info, solutions, and test data from R2
+through the API (`${API_BASE}/contests/:year/:code/...`) — see
+`app/contest/[contestYear]/[problemCode]/page.tsx`.
+
+Nothing in the application fetches `/past_contests/...` at runtime anymore. This
+directory is kept only until the R2 switchover is fully verified in production,
+then it will be deleted (it is also ~69MB and pushes individual files past the
+Cloudflare Workers 25MiB asset cap, which is why it cannot ship as static
+assets).
+
+Do not add new references to these paths. If you need contest data, use the R2
+API endpoints instead.


### PR DESCRIPTION
## Description

Three unrelated frontend/tooling bugfixes bundled into one PR.

**Bug 1 (primary) — solutions search dropdown was clipped.** On `/solutions`, the search autocomplete dropdown was cut off at the bottom edge of the blue hero band instead of overlaying the `ProblemTable` below it. Cause: the hero band div carried `overflow-hidden` (there to clip the decorative `FlickeringGrid`), which also clipped the absolutely-positioned dropdown. Fix: move `overflow-hidden` off the band and onto the `absolute inset-0` grid wrapper. The wrapper has the exact same bounds as the band, so the grid is still clipped identically, but the `z-50` dropdown (inside the `relative z-10` SectionContainer) now escapes the band and paints over the static table below. Band gradient/grain visuals and both light/dark themes are unchanged.

**Bug 2 — deprecate static `past_contests` data.** The app now serves all contest data from R2 via the API (`${API_BASE}/contests/...`); nothing fetches `/past_contests/...` at runtime. Added `website/public/past_contests/DEPRECATED.md` and a deprecation note on the last remaining source comment that references the path (`SolutionPreview.tsx`, which only inlines sample code).

**Bug 3 — mark `scripts/stage-r2.js` as bad.** Its `detectLanguage` heuristic mislabels solutions and it is superseded by the `/admin` R2 upload endpoint. Not deleted (kept for reference). Added a loud DEPRECATED / DO NOT USE header and guarded the body with an early `process.exit(1)` + message so it cannot be run accidentally.

## Changes

- `app/solutions/page.tsx`: relocate `overflow-hidden` from the hero band to the `FlickeringGrid` wrapper so the search dropdown is no longer clipped.
- `components/solutions/SolutionPreview.tsx`: deprecation note on the `past_contests` path comment.
- `public/past_contests/DEPRECATED.md`: new dev-facing deprecation notice.
- `scripts/stage-r2.js`: DEPRECATED header + early-exit run guard; executable logic left intact as reference.

## Testing

- `bun run typecheck` — passes.
- `bun run lint` — passes (only a pre-existing `no-page-custom-font` warning in `layout.tsx`, untouched).
- `bun run build` — succeeds, all 15 routes generated including `/solutions`.
- Manual: dropdown now overflows the hero band and overlays the table; grid clipping and hero visuals unchanged in both light and dark mode.

## Linked issues

Resolves #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] No `test_data` or other large files added to the repo
- [x] Docs/comments updated if behavior or APIs changed
