### PR TITLE
chore(backend): set workers_dev and preview_urls explicitly

### DIFF
--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -3,11 +3,17 @@
   "name": "cccsolutions-backend",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-08",
+  // Explicit, not inherited: workers_dev defaults to true and preview_urls
+  // defaults to workers_dev, so leaving these unset lets every deploy reassert
+  // the defaults over a dashboard change. Both URLs are gated by edge
+  // Cloudflare Access (see AGENTS.md); the public domain is WAF rate-limited.
+  "workers_dev": true,
+  "preview_urls": true,
   // Workers Cache (GA): a per-Worker edge cache in front of this Worker. Cache-
   // ability is driven entirely by the Cache-Control headers we set per route
   // (see src/r2/routes.ts) — /list and /preview opt in, /download opts out.
   "cache": {
-    "enabled": true
+    "enabled": true,
   },
   // "compatibility_flags": [
   //   "nodejs_compat"
@@ -21,13 +27,12 @@
   //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   //   }
   // ],
-   "r2_buckets": [
-     {
-       "binding": "TESTCASES_SOLUTIONS_BUCKET",
-       "bucket_name": "cccsolutions"
-     }
-   ]
-
+  "r2_buckets": [
+    {
+      "binding": "TESTCASES_SOLUTIONS_BUCKET",
+      "bucket_name": "cccsolutions",
+    },
+  ],
 
   // "d1_databases": [
   //   {


### PR DESCRIPTION
## What

Adds `"workers_dev": true` + `"preview_urls": true` to `backend/wrangler.jsonc`. **No behaviour change** — these are the values wrangler was already applying by default.

## Why

Both were unset. Per the [Wrangler docs](https://developers.cloudflare.com/workers/wrangler/configuration/), the config file is the source of truth and **overrides the dashboard on every deploy** — and `workers_dev` defaults to `true`, with `preview_urls` defaulting to `workers_dev`. So leaving them unset means every deploy silently reasserts the defaults over any dashboard change.

That's not hypothetical: it's exactly what was breaking the frontend. Its dashboard Preview toggle was ON, but the config omitted `preview_urls`, so each deploy reset it to OFF — which is why Git deployments reported success with no Preview URL. Pinning it in config is what fixed it (#175).

The backend's defaults happen to match the intended setup, so nothing was broken here. This just removes the trap: a dashboard change to either field would otherwise be reverted on the next deploy.

## Values match documented intent

Per `backend/AGENTS.md`:
> `*.workers.dev` and preview URLs are gated by **edge Cloudflare Access**... The public custom domains are intentionally public, protected by **WAF rate-limiting rules**.

Verified live: `cccsolutions-backend.willi64645.workers.dev` → `302` → Cloudflare Access login, no R2 data served. `api.cccsolutions.ca` → `200`, WAF-protected.

Also picks up prettier formatting on the file (trailing commas, `r2_buckets` indentation).

## Verification

`wrangler deploy --dry-run` clean — 633 KiB / **102 KiB gzipped**, no warnings.