### PR TITLE
feat(backend): supabase migration foundation (drizzle + CI-run migrations)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,69 @@
+name: db migrations
+
+# Migrations are applied ONLY by this workflow — never by a developer running
+# db:migrate against production. On a PR we prove the committed migrations apply
+# to a fresh database; on merge to main we apply them to the hosted project.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/src/db/**'
+      - 'backend/drizzle/**'
+      - 'backend/drizzle.config.ts'
+      - 'backend/supabase/**'
+      - '.github/workflows/db-migrate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'backend/drizzle/**'
+      - 'backend/drizzle.config.ts'
+      - '.github/workflows/db-migrate.yml'
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  # PRs: apply the committed migrations to a throwaway Supabase stack (which
+  # provides the auth schema + roles our migration references), and fail if
+  # schema.ts was changed without generating a matching migration.
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: bun install --frozen-lockfile
+      - name: Start local Supabase (Postgres + auth schema)
+        run: supabase start
+      - name: Apply migrations to the fresh database
+        run: bun run db:migrate
+        env:
+          DIRECT_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+      - name: Fail if schema.ts has an un-generated migration (drift)
+        run: |
+          bun run db:generate
+          if ! git diff --quiet -- drizzle; then
+            echo "::error::schema.ts changed but no migration was committed. Run 'bun run db:generate' and commit drizzle/."
+            git --no-pager diff -- drizzle
+            exit 1
+          fi
+
+  # Merge to main: the ONLY place production is migrated. DIRECT_DATABASE_URL
+  # lives only as a GitHub secret, never in a developer's .dev.vars, so prod
+  # cannot be migrated by hand.
+  deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Apply migrations to production
+        run: bun run db:migrate
+        env:
+          DIRECT_DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -46,9 +46,11 @@ jobs:
       - name: Fail if schema.ts has an un-generated migration (drift)
         run: |
           bun run db:generate
-          if ! git diff --quiet -- drizzle; then
+          # --porcelain, not `git diff`: a new migration is an UNTRACKED file, which
+          # `git diff` does not report.
+          if [ -n "$(git status --porcelain -- drizzle)" ]; then
             echo "::error::schema.ts changed but no migration was committed. Run 'bun run db:generate' and commit drizzle/."
-            git --no-pager diff -- drizzle
+            git status --porcelain -- drizzle
             exit 1
           fi
 
@@ -59,6 +61,11 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production
+    # Two merges landing close together must not migrate production concurrently.
+    # Never cancel a run mid-migration.
+    concurrency:
+      group: db-migrate-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -23,6 +23,10 @@ ADMIN_TOKEN=
 #   merge to main, never by a developer running db:migrate by hand.
 # DATABASE_URL — transaction pooler (6543 hosted / 54322 local). Used by the Worker
 #   at runtime, where a stateless pooled connection is what you want.
+#
+# In PROD, copy both from the Supabase dashboard's "Connect" panel — use the POOLER
+# host (postgres.<ref>@...pooler.supabase.com), NOT the IPv6-only "Direct connection"
+# (db.<ref>.supabase.co): Transaction pooler -> DATABASE_URL, Session pooler -> DIRECT.
 DIRECT_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 

--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -8,8 +8,25 @@ R2_ACCESS_KEY_ID=your-r2-access-key-id
 R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 
 # Bearer token for the /admin write endpoints (upload/delete). Leave empty to keep
-# admin locked in local dev; in prod set it via `wrangler versions secret put ADMIN_TOKEN`.
+# admin locked in local dev; in prod set it via `wrangler secret put ADMIN_TOKEN`.
 ADMIN_TOKEN=
 
-# Postgres / Supabase — used by drizzle-kit (db:* scripts)
-DATABASE_URL=postgres://user:pass@host:5432/dbname
+# ---------------------------------------------------------------------------
+# Postgres / Supabase
+# ---------------------------------------------------------------------------
+# Local dev uses the Supabase CLI stack (`supabase start`), which serves Postgres
+# on 127.0.0.1:54322 with password `postgres`. The defaults below point there, so
+# a fresh copy Just Works against your local stack with no editing.
+#
+# DIRECT_DATABASE_URL — session mode (5432 hosted / 54322 local). Used by drizzle-kit
+#   for migrations. Keep this pointed at LOCAL only: production is migrated by CI on
+#   merge to main, never by a developer running db:migrate by hand.
+# DATABASE_URL — transaction pooler (6543 hosted / 54322 local). Used by the Worker
+#   at runtime, where a stateless pooled connection is what you want.
+DIRECT_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Supabase API — set these as real backend Worker secrets in prod (`wrangler secret put`).
+# SUPABASE_SECRET_KEY replaces the deprecated service_role key; it is server-only.
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SECRET_KEY=your-supabase-secret-key

--- a/backend/docs/DATABASE.md
+++ b/backend/docs/DATABASE.md
@@ -1,0 +1,64 @@
+# Database & migrations
+
+How to change the database and test it. Read this before touching `src/db/schema.ts`.
+
+## The model: one owner per schema
+
+- **drizzle owns the `public` schema** — every table, index, and RLS policy is defined in `src/db/schema.ts` and turned into a migration by `drizzle-kit`.
+- **Supabase owns `auth`, `storage`, etc.** — we never migrate those; the local stack and the hosted project provide them.
+
+There is exactly **one** migration tool (drizzle-kit). Do not add a second (no `supabase migration`, no hand-run SQL). Two tools writing the same schema is what makes a database impossible to reproduce.
+
+## One-time local setup
+
+1. Install deps: `bun install`
+2. `cp .dev.vars.example .dev.vars` — the defaults already point at the local Supabase stack, so no editing is needed to run migrations.
+3. Start the local stack (Postgres + auth schema, in Docker):
+   ```
+   supabase start
+   ```
+   This is the "dev database". It's disposable — `supabase db reset` wipes it back to migrations-only, `supabase stop` shuts it down.
+
+## The loop (every schema change)
+
+1. **Edit** `src/db/schema.ts`.
+2. **Generate** the migration:
+   ```
+   bun run db:generate
+   ```
+   This writes a new `drizzle/NNNN_*.sql` and updates `drizzle/meta/`. **Commit these files** — the `.sql` is the source of truth, not the database.
+3. **Apply it to your local DB** to test:
+   ```
+   bun run db:migrate
+   ```
+   `db:migrate` uses `DIRECT_DATABASE_URL` from `.dev.vars`, which points at `localhost:54322` — your local stack. Inspect the result with `bun run db:studio`.
+4. **Open a PR.** CI spins up a throwaway Supabase, applies your migration to it, and **fails if you changed `schema.ts` without committing a generated migration** (the drift check). If CI is green, the migration applies cleanly from scratch.
+5. **Merge to main.** CI applies the migration to the hosted project. This is the only time production changes.
+
+## Golden rules
+
+- **Never hand-edit the database** (no ad-hoc SQL in the dashboard, no `db:push`). If it isn't a committed migration, it doesn't exist.
+- **Never run `db:migrate` against production.** You can't, by design: the production `DIRECT_DATABASE_URL` exists only as a GitHub Actions secret, never in anyone's `.dev.vars`. Your local `.dev.vars` only ever holds the `localhost:54322` URL.
+- **Production is migrated only by CI, only on merge to main** (`.github/workflows/db-migrate.yml`).
+- **RLS is enforced only for direct Supabase access** (the `authenticated` role). The Worker connects as a privileged role and bypasses RLS, so it must enforce ownership in the API layer — the policies are defense-in-depth, not the Worker's guard.
+
+## Where the connection strings live
+
+Two Postgres connection strings, different jobs:
+
+| Var | Port | Used by | Where it's set |
+| --- | --- | --- | --- |
+| `DIRECT_DATABASE_URL` | 5432 (hosted) / 54322 (local) | `drizzle-kit` migrations | local `.dev.vars` (local URL only); prod value is a **GitHub secret** |
+| `DATABASE_URL` | 6543 (hosted) / 54322 (local) | the Worker at runtime | local `.dev.vars`; prod value is a **backend Worker secret** |
+
+Migrations use the direct/session connection because DDL is unreliable through the transaction pooler; the Worker uses the pooler because it's stateless.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `bun run db:generate` | Diff `schema.ts` → new `drizzle/NNNN_*.sql` |
+| `bun run db:migrate` | Apply un-applied migrations to `DIRECT_DATABASE_URL` |
+| `bun run db:studio` | Browse the DB in the drizzle GUI |
+| `supabase start` / `stop` | Start / stop the local stack |
+| `supabase db reset` | Wipe local DB back to migrations-only |

--- a/backend/drizzle.config.ts
+++ b/backend/drizzle.config.ts
@@ -1,15 +1,19 @@
-import { config } from 'dotenv'
-import { defineConfig } from 'drizzle-kit'
+import { config } from 'dotenv';
+import { defineConfig } from 'drizzle-kit';
 
-// Single local env source: drizzle reads DATABASE_URL from .dev.vars (same file wrangler dev uses).
-config({ path: '.dev.vars' })
+// drizzle owns the `public` schema only — Supabase manages `auth`, `storage`, etc.
+// Migrations connect via DIRECT_DATABASE_URL, a session-mode connection (port 5432
+// hosted / 54322 local), because DDL is unreliable through the transaction pooler.
+// The Worker's runtime queries use the pooled DATABASE_URL instead.
+config({ path: '.dev.vars' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',
   out: './drizzle',
   dialect: 'postgresql',
+  schemaFilter: ['public'],
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: process.env.DIRECT_DATABASE_URL!,
   },
   casing: 'snake_case',
-})
+});

--- a/backend/drizzle/0000_ordinary_captain_stacy.sql
+++ b/backend/drizzle/0000_ordinary_captain_stacy.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "profiles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"auth_user_id" uuid,
+	"username" text NOT NULL,
+	"avatar_url" text,
+	"role" text DEFAULT 'user' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "profiles_auth_user_id_unique" UNIQUE("auth_user_id"),
+	CONSTRAINT "profiles_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+ALTER TABLE "profiles" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_auth_user_id_users_id_fk" FOREIGN KEY ("auth_user_id") REFERENCES "auth"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE POLICY "profiles_select_all" ON "profiles" AS PERMISSIVE FOR SELECT TO public USING (true);--> statement-breakpoint
+CREATE POLICY "profiles_insert_self" ON "profiles" AS PERMISSIVE FOR INSERT TO "authenticated" WITH CHECK ("profiles"."auth_user_id" = (select auth.uid()));--> statement-breakpoint
+CREATE POLICY "profiles_update_self" ON "profiles" AS PERMISSIVE FOR UPDATE TO "authenticated" USING ("profiles"."auth_user_id" = (select auth.uid())) WITH CHECK ("profiles"."auth_user_id" = (select auth.uid()));

--- a/backend/drizzle/meta/0000_snapshot.json
+++ b/backend/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,130 @@
+{
+  "id": "a32da630-a7fb-40ad-8a1d-33e0a64ce207",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_auth_user_id_users_id_fk": {
+          "name": "profiles_auth_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_auth_user_id_unique": {
+          "name": "profiles_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "profiles_username_unique": {
+          "name": "profiles_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {
+        "profiles_select_all": {
+          "name": "profiles_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "profiles_insert_self": {
+          "name": "profiles_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        },
+        "profiles_update_self": {
+          "name": "profiles_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"profiles\".\"auth_user_id\" = (select auth.uid())",
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1784255137296,
+      "tag": "0000_ordinary_captain_stacy",
+      "breakpoints": true
+    }
+  ]
+}

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,0 +1,14 @@
+// src/db/index.ts
+//
+// One postgres client per request — Workers can't reuse sockets across requests.
+// Pooling is handled by Supabase's transaction pooler (DATABASE_URL, port 6543),
+// so a fresh max:1 client per call just borrows an idle pooled connection.
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+import type { Bindings } from '../types';
+
+export function getDb(env: Bindings) {
+  const client = postgres(env.DATABASE_URL, { max: 1 });
+  return drizzle(client, { schema });
+}

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -1,0 +1,51 @@
+// src/db/schema.ts
+//
+// This file is the single source of truth for the `public` schema.
+// The migration loop is: edit this file -> `bun run db:generate` (writes a new
+// drizzle/NNNN_*.sql) -> commit the .sql -> CI applies it. Never hand-edit the
+// database, and never run `db:migrate` against production yourself (see the CI
+// workflow — prod is migrated only on merge to main).
+//
+// profiles.auth_user_id is nullable and separate from profiles.id:
+//   - Real, logged-in users: auth_user_id points at their auth.users row.
+//   - Migrated PocketBase users (added later): auth_user_id is NULL — they exist
+//     only so old posts still show an author; nobody can log in as them.
+
+import { sql } from 'drizzle-orm';
+import { pgTable, uuid, text, timestamp, pgPolicy } from 'drizzle-orm/pg-core';
+import { authUsers, authenticatedRole } from 'drizzle-orm/supabase';
+
+export const profiles = pgTable(
+  'profiles',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    authUserId: uuid('auth_user_id')
+      .unique()
+      .references(() => authUsers.id, { onDelete: 'set null' }), // nullable — see note above
+    username: text('username').notNull().unique(),
+    avatarUrl: text('avatar_url'),
+    role: text('role').notNull().default('user'), // "user" | "moderator" | "admin"
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // RLS lives in the schema so it's generated in the same migration as the table
+    // and can never drift from a column change. These policies only bind the
+    // `authenticated` role (direct Supabase access); the Worker connects as a
+    // privileged role and enforces ownership in the API layer.
+    pgPolicy('profiles_select_all', {
+      for: 'select',
+      using: sql`true`,
+    }),
+    pgPolicy('profiles_insert_self', {
+      for: 'insert',
+      to: authenticatedRole,
+      withCheck: sql`${t.authUserId} = (select auth.uid())`,
+    }),
+    pgPolicy('profiles_update_self', {
+      for: 'update',
+      to: authenticatedRole,
+      using: sql`${t.authUserId} = (select auth.uid())`,
+      withCheck: sql`${t.authUserId} = (select auth.uid())`,
+    }),
+  ],
+);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -15,4 +15,13 @@ export type Bindings = {
   // Bearer token gating the /admin write endpoints (upload/delete). Set in prod
   // via `wrangler versions secret put ADMIN_TOKEN`; fail-closed if unset.
   ADMIN_TOKEN: string;
+
+  // Supabase — set as backend Worker secrets (`wrangler secret put`).
+  // DATABASE_URL: transaction-pooler connection string (port 6543) for runtime queries.
+  // SUPABASE_URL: project API URL, e.g. https://xyz.supabase.co (JWKS + Storage).
+  // SUPABASE_SECRET_KEY: server-only secret key (replaces the deprecated service_role
+  //   key); used for trusted server-side Storage/admin calls. Never sent to a browser.
+  DATABASE_URL: string;
+  SUPABASE_URL: string;
+  SUPABASE_SECRET_KEY: string;
 };

--- a/backend/supabase/.gitignore
+++ b/backend/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -1,0 +1,357 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "backend"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -18,9 +18,13 @@
   // "compatibility_flags": [
   //   "nodejs_compat"
   // ],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
+  // Public, non-secret config lives here so a deploy keeps it in sync (no dashboard
+  // drift). SUPABASE_URL is the project's API gateway — not a secret (it also ships
+  // in the frontend bundle). The real secrets — DATABASE_URL, SUPABASE_SECRET_KEY,
+  // ADMIN_TOKEN, R2_* — stay as `wrangler secret` and must never be added here.
+  "vars": {
+    "SUPABASE_URL": "https://ccjcesfbqlnosienatsz.supabase.co",
+  },
   // "kv_namespaces": [
   //   {
   //     "binding": "MY_KV_NAMESPACE",

--- a/website/.env.local.example
+++ b/website/.env.local.example
@@ -1,0 +1,21 @@
+# Frontend environment — copy to .env.local and fill in real values.
+# .env.local is gitignored — never commit it.
+#
+# IMPORTANT: every var here is NEXT_PUBLIC_*, which Next.js BAKES INTO THE BUNDLE
+# AT BUILD TIME. They are read by `next build`, not at Worker runtime. So in the
+# cloud they belong in the BUILD environment, not the Worker's Secrets tab:
+#   - Cloudflare: Workers Builds -> Build -> Variables and Secrets
+#   - Netlify:    Site config -> Environment variables
+# Setting them as frontend Worker runtime secrets does nothing (that was the bug).
+
+# Supabase project URL and publishable key.
+# The publishable key replaces the deprecated anon key; it is browser-safe (RLS is
+# the real guard, and all privileged operations go through the Hono backend).
+# Found in: Supabase dashboard -> Settings -> API
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+
+# Hono API base URL — NO trailing slash (paths are joined as `${API_URL}/contests/...`).
+# Local dev: http://localhost:8787
+# Production: https://api.cccsolutions.ca
+NEXT_PUBLIC_API_URL=http://localhost:8787

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -322,7 +322,8 @@ body {
   color: hsl(var(--foreground-default)) !important;
 }
 /* Lists */
-.ql-editor ol, .ql-editor ul {
+.ql-editor ol,
+.ql-editor ul {
   padding-left: 1.5rem !important;
 }
 
@@ -366,7 +367,6 @@ body {
 [data-theme='dark'] .ql-snow .ql-picker-item {
   color: hsl(var(--foreground-light)) !important;
 }
-
 
 /* Light mode background for Quill editor */
 .light .ql-container,


### PR DESCRIPTION
## Why

Rebuilds the Supabase groundwork **foundation-first**, after closing #176 (too large to review, and the DB state wasn't reproducible from the repo — migration `.sql` files were never committed, triggers lived only in the dashboard, and the PocketBase import script couldn't run). This PR establishes the pipeline so every future change is a small, reviewable, CI-applied migration.

## What's here

- **One migration authority.** drizzle owns the `public` schema; Supabase owns `auth`/`storage`. No hand-run SQL, no `db:push`.
- **`profiles` table** with a real, committed migration (`backend/drizzle/0000_ordinary_captain_stacy.sql`).
- **CI** (`.github/workflows/db-migrate.yml`):
  - *PRs* → spin up a throwaway Supabase, apply the committed migrations to it, and fail if `schema.ts` changed without a committed migration (drift check).
  - *Merge to main* → apply migrations to the hosted project. **The only place production is ever migrated.**
- **Env examples corrected**, split by deployment target, using the **non-deprecated** keys (`SUPABASE_SECRET_KEY`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` — not `service_role`/`anon`).
- **`backend/docs/DATABASE.md`** — how to write and test schema changes.

## The rule this enforces

Production's `DIRECT_DATABASE_URL` exists **only** as a GitHub Actions secret — never in anyone's `.dev.vars`. So production can be migrated *only* by CI on merge to main; nobody can do it by hand.

## Secrets to set (before merging — the merge triggers the prod-migrate job)

**1. Backend Worker `cccsolutions-backend`** — `cd backend && bunx wrangler secret put <NAME>`
| Secret | Value |
| --- | --- |
| `DATABASE_URL` | Transaction **pooler** string, port **6543** (new rotated password) |
| `SUPABASE_URL` | `https://ccjcesfbqlnosienatsz.supabase.co` |
| `SUPABASE_SECRET_KEY` | Settings → API → API Keys → secret key |

(`ADMIN_TOKEN` + `R2_*` already set.)

**2. GitHub → Settings → Secrets and variables → Actions**
| Secret | Value |
| --- | --- |
| `DIRECT_DATABASE_URL` | **Direct/session** string, port **5432** (new password) |

Also create a `production` environment (the deploy job references it).

**3. Frontend build env** — Cloudflare **Workers Builds → Build → Variables** *and* Netlify **Site config → Environment variables** (both, same values):
| Var | Value |
| --- | --- |
| `NEXT_PUBLIC_SUPABASE_URL` | `https://ccjcesfbqlnosienatsz.supabase.co` |
| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Settings → API → publishable key |
| `NEXT_PUBLIC_API_URL` | `https://api.cccsolutions.ca` (no trailing slash) |

⚠️ These are **build-time** vars — do **not** put them in the frontend Worker's *Secrets* tab (that does nothing; remove any that are there).

## Not in this PR (on purpose)

Auth middleware, forum/user routes, RLS triggers, and the PocketBase data import — those land as small PRs on top of this, each with its own migration.