### PR TITLE
chore(backend): drop unused SUPABASE_SECRET_KEY from env example and Bindings

### DIFF
--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -29,8 +29,3 @@ ADMIN_TOKEN=
 # (db.<ref>.supabase.co): Transaction pooler -> DATABASE_URL, Session pooler -> DIRECT.
 DIRECT_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
-
-# Supabase API — set these as real backend Worker secrets in prod (`wrangler secret put`).
-# SUPABASE_SECRET_KEY replaces the deprecated service_role key; it is server-only.
-SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SECRET_KEY=your-supabase-secret-key

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -16,12 +16,10 @@ export type Bindings = {
   // via `wrangler versions secret put ADMIN_TOKEN`; fail-closed if unset.
   ADMIN_TOKEN: string;
 
-  // Supabase — set as backend Worker secrets (`wrangler secret put`).
-  // DATABASE_URL: transaction-pooler connection string (port 6543) for runtime queries.
-  // SUPABASE_URL: project API URL, e.g. https://xyz.supabase.co (JWKS + Storage).
-  // SUPABASE_SECRET_KEY: server-only secret key (replaces the deprecated service_role
-  //   key); used for trusted server-side Storage/admin calls. Never sent to a browser.
+  // Supabase.
+  // DATABASE_URL: transaction-pooler connection string (port 6543) for runtime
+  //   queries; a Worker secret (`wrangler secret put`).
+  // SUPABASE_URL: project API URL — a non-secret var, set in wrangler.jsonc.
   DATABASE_URL: string;
   SUPABASE_URL: string;
-  SUPABASE_SECRET_KEY: string;
 };


### PR DESCRIPTION
## Why

`SUPABASE_SECRET_KEY` is declared in `Bindings` and documented in `.dev.vars.example`, but **no code reads it** — the same "documented but unused" problem this foundation work was meant to fix (#176 shipped a `SUPABASE_JWT_SECRET` nothing read).

It's worse than merely unused: a secret slot in a **local-dev** file invites pasting a **production** credential into `.dev.vars` — the exact habit the CI-only migration setup exists to remove. For local dev you'd use the key `supabase start` prints, never the hosted one.

It should land with the PR that adds server-side Storage uploads (the code that actually uses it).

## Also

Drops `SUPABASE_URL` from `.dev.vars.example` — it's a non-secret var in `wrangler.jsonc`, so `wrangler dev` already supplies it. Having it in both places was a leftover from moving it into config.

It stays in `Bindings` (it genuinely exists in the env at runtime); only the redundant `.dev.vars` entry goes.

## Risk

None. `bun run typecheck` shows no new errors — nothing referenced the removed field.