### PR TITLE
fix(website): distinguish missing vs failed solutions on problem page

### DIFF
--- a/backend/src/schemas/r2.ts
+++ b/backend/src/schemas/r2.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod';
 
-// A CCC problem: contest year + code. Codes are s/j 1-5 (Senior/Junior) and p1-5 (pre-2000).
-export const problemParamsSchema = z.object({
-  year: z.string().regex(/^\d{4}$/),
-  code: z.string().regex(/^[sjp][1-5]$/),
-});
+// A CCC problem: contest year + code. Codes are s/j 1-5 (Senior/Junior, 2000+) and
+// p1-5 (pre-2000, single division) — the letter is only valid for its own era.
+export const problemParamsSchema = z
+  .object({
+    year: z.string().regex(/^\d{4}$/),
+    code: z.string().regex(/^[sjp][1-5]$/),
+  })
+  .refine(({ year, code }) => (Number(year) < 2000 ? code[0] === 'p' : code[0] !== 'p'), {
+    message: 'p-codes only exist before 2000; s/j-codes only exist from 2000 onward',
+    path: ['code'],
+  });
 
 // A file within a problem, relative to contests/<year>/<code>/ (mirrors scripts/stage-r2.js):
 //   tests/<n>.in|out        (samples under tests/sample/)

--- a/backend/test/r2/schemas.test.ts
+++ b/backend/test/r2/schemas.test.ts
@@ -2,10 +2,27 @@ import { describe, it, expect } from 'vitest';
 import { problemParamsSchema, fileSchema } from '../../src/schemas';
 
 describe('problemParamsSchema', () => {
-  it('accepts valid CCC problem codes', () => {
-    for (const code of ['s1', 's5', 'j1', 'j5', 'p1', 'p5']) {
+  it('accepts s/j codes for 2000 onward', () => {
+    for (const code of ['s1', 's5', 'j1', 'j5']) {
       expect(problemParamsSchema.safeParse({ year: '2024', code }).success).toBe(true);
+      expect(problemParamsSchema.safeParse({ year: '2000', code }).success).toBe(true);
     }
+  });
+
+  it('accepts p codes only before 2000', () => {
+    for (const code of ['p1', 'p5']) {
+      expect(problemParamsSchema.safeParse({ year: '1999', code }).success).toBe(true);
+    }
+  });
+
+  it('rejects p codes from 2000 onward and s/j codes before 2000', () => {
+    const bad = [
+      { year: '2024', code: 'p1' }, // p-codes stopped existing after 1999
+      { year: '2000', code: 'p1' }, // 2000 is the first s/j year, not p
+      { year: '1999', code: 's1' }, // s/j didn't exist yet
+      { year: '1996', code: 'j1' },
+    ];
+    for (const b of bad) expect(problemParamsSchema.safeParse(b).success).toBe(false);
   });
 
   it('rejects bad years and codes', () => {

--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -13,6 +13,7 @@ import {
   DownloadIcon,
   ExclamationTriangleIcon,
 } from '@radix-ui/react-icons';
+import { toast } from 'sonner';
 import { Card, CardContent } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
 import { DownloadDialog } from '../../../../components/contest/DownloadDialog';
@@ -51,10 +52,8 @@ interface SolutionMeta {
 interface SolutionEntry {
   code: string;
   language: string;
-  // Present for real solutions (enables the per-card download); absent for the
-  // "no solution yet" placeholder entry.
-  n?: number;
-  ext?: string;
+  n: number;
+  ext: string;
 }
 
 interface ListResponse {
@@ -64,6 +63,9 @@ interface ListResponse {
 
 const SOLUTION_MISSING_MESSAGE =
   'Solution does not currently exist. If you have a solution, please upload your solution along with a commented explanation on our forum. Thank you!';
+
+const SOLUTION_ERROR_MESSAGE =
+  'Unable to load solutions right now. The API may be temporarily unavailable, please try again shortly.';
 
 const formatSize = (bytes: number) =>
   bytes > 1024 * 1024
@@ -76,6 +78,7 @@ const Problem = () => {
     problemCode: string;
   }>();
   const [solutions, setSolutions] = useState<SolutionEntry[]>([]);
+  const [solutionsError, setSolutionsError] = useState(false);
   const [activeTab, setActiveTab] = useState<number | null>(null);
   const [testCaseData, setTestCaseData] = useState<TestCaseData>({ input: '', output: '' });
   const [testCaseState, setTestCaseState] = useState<'idle' | 'loading' | 'success' | 'error'>(
@@ -136,6 +139,7 @@ const Problem = () => {
       setLoading(true);
       setActiveTab(null);
       setTestCaseState('idle');
+      setSolutionsError(false);
 
       try {
         const res = await fetch(`${API_BASE}/contests/${contestYear}/${problemCode}/list`);
@@ -171,18 +175,28 @@ const Problem = () => {
         const validSolutions = solutionEntries.filter(
           (e): e is NonNullable<typeof e> => e !== null
         );
-        setSolutions(
-          validSolutions.length > 0
-            ? validSolutions
-            : [{ code: SOLUTION_MISSING_MESSAGE, language: 'text' }]
-        );
+        const attemptedCount = (data.solutions ?? []).length;
+
+        if (validSolutions.length > 0) {
+          setSolutions(validSolutions);
+        } else if (attemptedCount === 0) {
+          // API responded fine, there just isn't a solution uploaded yet.
+          setSolutions([]);
+        } else {
+          // Solutions exist server-side but every fetch for them failed.
+          setSolutions([]);
+          setSolutionsError(true);
+          toast.error('Unable to load solutions. The API may be temporarily unavailable.');
+        }
       } catch (error) {
         console.error('Error loading contest data:', error);
         if (cancelled) return;
         setTests([]);
         setSolutionsMeta([]);
         setTestCaseState('error');
-        setSolutions([{ code: SOLUTION_MISSING_MESSAGE, language: 'text' }]);
+        setSolutions([]);
+        setSolutionsError(true);
+        toast.error('Unable to load solutions. The API may be temporarily unavailable.');
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -422,7 +436,11 @@ const Problem = () => {
             <h2 className="text-xl font-semibold text-foreground">
               {loading
                 ? 'Loading solutions…'
-                : `${solutions.length} Solution${solutions.length !== 1 ? 's' : ''} available`}
+                : solutionsError
+                  ? 'Solutions unavailable'
+                  : solutions.length === 0
+                    ? 'No solution available yet'
+                    : `${solutions.length} Solution${solutions.length !== 1 ? 's' : ''} available`}
             </h2>
           </div>
 
@@ -430,6 +448,23 @@ const Problem = () => {
             <div className="animate-pulse">
               <div className="h-64 bg-surface-200 rounded-lg" />
             </div>
+          ) : solutions.length === 0 ? (
+            <Card>
+              <div
+                className={`flex items-center justify-center gap-2 py-8 ${
+                  solutionsError ? 'text-destructive' : 'text-foreground-lighter'
+                }`}
+              >
+                {solutionsError ? (
+                  <ExclamationTriangleIcon width="18" height="18" />
+                ) : (
+                  <InfoCircledIcon width="18" height="18" />
+                )}
+                <p className="font-medium text-sm">
+                  {solutionsError ? SOLUTION_ERROR_MESSAGE : SOLUTION_MISSING_MESSAGE}
+                </p>
+              </div>
+            </Card>
           ) : (
             <div className="flex flex-col gap-4">
               {solutions.map((solution, idx) => (
@@ -442,16 +477,14 @@ const Problem = () => {
                       <span className="text-xs font-medium text-foreground-lighter uppercase">
                         {solution.language}
                       </span>
-                      {solution.n !== undefined && solution.ext && (
-                        <a
-                          href={downloadUrl(`solutions/${solution.n}.${solution.ext}`)}
-                          className="text-foreground-lighter hover:text-brand transition-colors"
-                          aria-label={`Download solution ${idx + 1}`}
-                          title="Download solution"
-                        >
-                          <DownloadIcon width="15" height="15" />
-                        </a>
-                      )}
+                      <a
+                        href={downloadUrl(`solutions/${solution.n}.${solution.ext}`)}
+                        className="text-foreground-lighter hover:text-brand transition-colors"
+                        aria-label={`Download solution ${idx + 1}`}
+                        title="Download solution"
+                      >
+                        <DownloadIcon width="15" height="15" />
+                      </a>
                     </div>
                   </div>
                   <SyntaxHighlighter

--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -67,7 +67,8 @@ const SOLUTION_MISSING_MESSAGE =
 const SOLUTION_ERROR_MESSAGE =
   'Unable to load solutions right now. The API may be temporarily unavailable, please try again shortly.';
 
-const PROBLEM_INVALID_MESSAGE = 'This problem does not exist. Double check the year and problem code.';
+const PROBLEM_INVALID_MESSAGE =
+  'This problem does not exist. Double check the year and problem code.';
 
 const PROBLEM_ERROR_MESSAGE =
   'Unable to load this problem right now. The API may be temporarily unavailable, please try again shortly.';
@@ -471,7 +472,9 @@ const Problem = () => {
             <Card>
               <div
                 className={`flex items-center justify-center gap-2 py-8 ${
-                  listStatus === 'error' || solutionsError ? 'text-destructive' : 'text-foreground-lighter'
+                  listStatus === 'error' || solutionsError
+                    ? 'text-destructive'
+                    : 'text-foreground-lighter'
                 }`}
               >
                 {listStatus === 'error' || solutionsError ? (

--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -67,6 +67,11 @@ const SOLUTION_MISSING_MESSAGE =
 const SOLUTION_ERROR_MESSAGE =
   'Unable to load solutions right now. The API may be temporarily unavailable, please try again shortly.';
 
+const PROBLEM_INVALID_MESSAGE = 'This problem does not exist. Double check the year and problem code.';
+
+const PROBLEM_ERROR_MESSAGE =
+  'Unable to load this problem right now. The API may be temporarily unavailable, please try again shortly.';
+
 const formatSize = (bytes: number) =>
   bytes > 1024 * 1024
     ? `${(bytes / (1024 * 1024)).toFixed(1)}MB`
@@ -79,6 +84,7 @@ const Problem = () => {
   }>();
   const [solutions, setSolutions] = useState<SolutionEntry[]>([]);
   const [solutionsError, setSolutionsError] = useState(false);
+  const [listStatus, setListStatus] = useState<'loading' | 'invalid' | 'error' | 'ok'>('loading');
   const [activeTab, setActiveTab] = useState<number | null>(null);
   const [testCaseData, setTestCaseData] = useState<TestCaseData>({ input: '', output: '' });
   const [testCaseState, setTestCaseState] = useState<'idle' | 'loading' | 'success' | 'error'>(
@@ -140,12 +146,25 @@ const Problem = () => {
       setActiveTab(null);
       setTestCaseState('idle');
       setSolutionsError(false);
+      setListStatus('loading');
 
       try {
         const res = await fetch(`${API_BASE}/contests/${contestYear}/${problemCode}/list`);
+
+        // 400 means the year/code itself is invalid (e.g. j8, or a s/j code
+        // before 2000) — a different situation from a real API failure.
+        if (res.status === 400) {
+          if (cancelled) return;
+          setTests([]);
+          setSolutionsMeta([]);
+          setSolutions([]);
+          setListStatus('invalid');
+          return;
+        }
         if (!res.ok) throw new Error(`list ${res.status}`);
         const data: ListResponse = await res.json();
         if (cancelled) return;
+        setListStatus('ok');
 
         // Show sample cases first, then graded — each group by ascending n.
         const listTests = [...(data.tests ?? [])].sort(
@@ -153,7 +172,6 @@ const Problem = () => {
         );
         setTests(listTests);
         setSolutionsMeta([...(data.solutions ?? [])].sort((a, b) => a.n - b.n));
-        if (listTests.length === 0) setTestCaseState('error');
 
         const solutionEntries = await Promise.all(
           (data.solutions ?? []).map(async (s) => {
@@ -193,10 +211,9 @@ const Problem = () => {
         if (cancelled) return;
         setTests([]);
         setSolutionsMeta([]);
-        setTestCaseState('error');
         setSolutions([]);
-        setSolutionsError(true);
-        toast.error('Unable to load solutions. The API may be temporarily unavailable.');
+        setListStatus('error');
+        toast.error('Unable to load this problem. The API may be temporarily unavailable.');
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -436,11 +453,13 @@ const Problem = () => {
             <h2 className="text-xl font-semibold text-foreground">
               {loading
                 ? 'Loading solutions…'
-                : solutionsError
-                  ? 'Solutions unavailable'
-                  : solutions.length === 0
-                    ? 'No solution available yet'
-                    : `${solutions.length} Solution${solutions.length !== 1 ? 's' : ''} available`}
+                : listStatus === 'invalid'
+                  ? 'Problem not found'
+                  : listStatus === 'error' || solutionsError
+                    ? 'Solutions unavailable'
+                    : solutions.length === 0
+                      ? 'No solution available yet'
+                      : `${solutions.length} Solution${solutions.length !== 1 ? 's' : ''} available`}
             </h2>
           </div>
 
@@ -452,16 +471,22 @@ const Problem = () => {
             <Card>
               <div
                 className={`flex items-center justify-center gap-2 py-8 ${
-                  solutionsError ? 'text-destructive' : 'text-foreground-lighter'
+                  listStatus === 'error' || solutionsError ? 'text-destructive' : 'text-foreground-lighter'
                 }`}
               >
-                {solutionsError ? (
+                {listStatus === 'error' || solutionsError ? (
                   <ExclamationTriangleIcon width="18" height="18" />
                 ) : (
                   <InfoCircledIcon width="18" height="18" />
                 )}
                 <p className="font-medium text-sm">
-                  {solutionsError ? SOLUTION_ERROR_MESSAGE : SOLUTION_MISSING_MESSAGE}
+                  {listStatus === 'invalid'
+                    ? PROBLEM_INVALID_MESSAGE
+                    : listStatus === 'error'
+                      ? PROBLEM_ERROR_MESSAGE
+                      : solutionsError
+                        ? SOLUTION_ERROR_MESSAGE
+                        : SOLUTION_MISSING_MESSAGE}
                 </p>
               </div>
             </Card>
@@ -529,30 +554,49 @@ const Problem = () => {
 
           <Card>
             {/* Tab strip */}
-            <div className="flex items-center p-3 border-b border-border-default overflow-x-auto">
-              {tests.map((test, idx) => (
-                <button
-                  key={`${test.sample ? 'sample' : 'case'}-${test.n}`}
-                  onClick={() => handleTabClick(idx)}
-                  className={`px-3 py-1 mr-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
-                    activeTab === idx
-                      ? 'bg-brand-500 text-white'
-                      : 'bg-surface-200 text-foreground-light hover:bg-surface-300 hover:text-foreground'
-                  }`}
-                >
-                  {test.sample ? `Sample ${test.n}` : `Case ${test.n}`}
-                </button>
-              ))}
-            </div>
+            {tests.length > 0 && (
+              <div className="flex items-center p-3 border-b border-border-default overflow-x-auto">
+                {tests.map((test, idx) => (
+                  <button
+                    key={`${test.sample ? 'sample' : 'case'}-${test.n}`}
+                    onClick={() => handleTabClick(idx)}
+                    className={`px-3 py-1 mr-2 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
+                      activeTab === idx
+                        ? 'bg-brand-500 text-white'
+                        : 'bg-surface-200 text-foreground-light hover:bg-surface-300 hover:text-foreground'
+                    }`}
+                  >
+                    {test.sample ? `Sample ${test.n}` : `Case ${test.n}`}
+                  </button>
+                ))}
+              </div>
+            )}
 
             <div className="p-4">
-              {activeTab === null && tests.length > 0 ? (
+              {listStatus === 'invalid' ? (
+                <div className="flex items-center justify-center gap-2 py-8 text-foreground-lighter">
+                  <InfoCircledIcon width="20" height="20" />
+                  <p className="font-medium text-sm">{PROBLEM_INVALID_MESSAGE}</p>
+                </div>
+              ) : listStatus === 'error' ? (
+                <div className="flex items-center justify-center gap-2 py-8 text-destructive">
+                  <ExclamationTriangleIcon width="20" height="20" />
+                  <p className="font-medium text-sm">{PROBLEM_ERROR_MESSAGE}</p>
+                </div>
+              ) : tests.length === 0 ? (
+                <div className="flex items-center justify-center py-8 text-destructive">
+                  <InfoCircledIcon width="20" height="20" className="mr-2" />
+                  <p className="font-medium">
+                    Test case not available. See GitHub repo for test data.
+                  </p>
+                </div>
+              ) : activeTab === null ? (
                 <div className="text-center py-8 text-foreground-lighter text-sm">
                   Select a test case to view input and output
                 </div>
               ) : testCaseState === 'loading' ? (
                 <div className="text-center py-8">
-                  <div className="inline-block animate-spin rounded-full size-8 border-b-2 border-brand" />
+                  <div className="inline-block animate-spin rounded-full size-8 border-4 border-surface-300 border-t-brand" />
                   {(() => {
                     if (activeTest) {
                       const maxBytes = Math.max(activeTest.inputBytes, activeTest.outputBytes);

--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -13,7 +13,6 @@ import {
   DownloadIcon,
   ExclamationTriangleIcon,
 } from '@radix-ui/react-icons';
-import { toast } from 'sonner';
 import { Card, CardContent } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
 import { DownloadDialog } from '../../../../components/contest/DownloadDialog';
@@ -205,7 +204,6 @@ const Problem = () => {
           // Solutions exist server-side but every fetch for them failed.
           setSolutions([]);
           setSolutionsError(true);
-          toast.error('Unable to load solutions. The API may be temporarily unavailable.');
         }
       } catch (error) {
         console.error('Error loading contest data:', error);
@@ -214,7 +212,6 @@ const Problem = () => {
         setSolutionsMeta([]);
         setSolutions([]);
         setListStatus('error');
-        toast.error('Unable to load this problem. The API may be temporarily unavailable.');
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -576,7 +573,12 @@ const Problem = () => {
             )}
 
             <div className="p-4">
-              {listStatus === 'invalid' ? (
+              {loading ? (
+                <div className="text-center py-8">
+                  <div className="inline-block animate-spin rounded-full size-8 border-4 border-surface-300 border-t-brand" />
+                  <p className="mt-2 text-foreground-light">Loading test cases…</p>
+                </div>
+              ) : listStatus === 'invalid' ? (
                 <div className="flex items-center justify-center gap-2 py-8 text-foreground-lighter">
                   <InfoCircledIcon width="20" height="20" />
                   <p className="font-medium text-sm">{PROBLEM_INVALID_MESSAGE}</p>

--- a/website/constants.ts
+++ b/website/constants.ts
@@ -78,7 +78,7 @@ const problems: Problem[] = [
     difficulty: 'Hard',
     tags: ['number theory', 'constructive'],
     link: '/contest/2026/s3',
-    hasSolution: false,
+    hasSolution: true,
   },
   {
     name: '2026 S4 - Minecarts',


### PR DESCRIPTION
## Description

The problem page couldn't tell apart three different situations, and rendered them all identically:

1. **A genuinely nonexistent problem code** (e.g. `/contest/2026/j8` — Junior only goes up to J5) hit `/list`, got a non-2xx, and fell into the same bucket as an actual API outage.
2. **A real API failure** (network error, 5xx, or every per-solution preview fetch failing) showed the exact same copy as (3).
3. **A problem that genuinely has no solution/test data yet** (API responds fine, just empty arrays) — the only case the old copy was actually written for.

On top of that, the header always said "N Solution(s) available" even when what was rendered was a placeholder message inside a fake syntax-highlighted code block — so a broken API could visually read as "1 Solution available."

Backend-side, `problemParamsSchema` also allowed any letter+year combination (e.g. `p1` for year `2024`, or `s1` for year `1999`) even though CCC's actual history is: P1-P5 only existed pre-2000 (single division), S/J split started in 2000. So `/contests/2024/p1/list` was incorrectly treated as a valid-but-empty problem instead of an invalid one.

## Changes

- `backend/src/schemas/r2.ts`: `problemParamsSchema` is now year-aware via `.refine()` — `p`-codes only validate for `year < 2000`, `s`/`j`-codes only validate for `year >= 2000`. Invalid combinations now correctly 400.
- `backend/test/r2/schemas.test.ts`: updated/added cases for the year-aware behavior (the old test asserted `p1` was valid for `2024`, which was wrong).
- `website/.../ProblemPageClient.tsx`:
  - Added a page-level `listStatus: 'loading' | 'invalid' | 'error' | 'ok'` derived from the `/list` response (`400` → `invalid`, thrown/network/5xx → `error`, else `ok`), driving both the Solutions and Test cases sections.
  - `solutions` state now only ever holds real, successfully-fetched entries — never a placeholder "code" string — so the header count and the code-view are never out of sync with reality.
  - Distinct copy for each of the four states: invalid problem, real error (+ `toast.error` via the Sonner instance already mounted in `Providers.tsx`), genuinely-missing-yet, and success. Same three-way split now applies to the Test cases panel (tab strip only renders when there are real tests; the old "Test case not available" copy is preserved as-is for the genuinely-empty case, untouched for real per-tab fetch errors, per feedback in review).
  - Fixed the test-case loading spinner: it only had `border-b-2` (one edge), so it rendered as a rotating sliver rather than a ring. Now `border-4 border-surface-300 border-t-brand` for a solid-thickness circle with a visible rotating highlight.
- `website/constants.ts`: `2026 S3 - Common Card Choice` had a stale `hasSolution: false` — a solution has since been added to R2.

## Testing

- Backend: `bun run typecheck`, `bun run lint`, and `bun run test` all pass (40 tests, including new schema coverage for the year/code boundary).
- Website: `tsc --noEmit` and `eslint` pass on the changed file.
- Traced all four `listStatus`/`solutionsError` branches by hand against the rewritten `loadContest` logic; did not exercise a live 5xx/network failure against a running instance.

## Linked issues

Resolves #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [ ] Docs/comments updated if behavior or APIs changed