### PR TITLE
feat(backend): cron keep-alive so Supabase free tier doesn't pause

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import type { Bindings } from './types';
 import r2 from './r2/routes';
 import admin from './admin/routes';
+import { scheduled } from './scheduled';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -36,4 +37,7 @@ app.get('/health', (c) => {
 app.route('/contests', r2);
 app.route('/admin', admin);
 
-export default app;
+// `app` is exported by name for tests (Hono's app.request/app.fetch helpers);
+// the default export is the Worker's runtime handler (HTTP + cron).
+export { app };
+export default { fetch: app.fetch, scheduled } satisfies ExportedHandler<Bindings>;

--- a/backend/src/scheduled.ts
+++ b/backend/src/scheduled.ts
@@ -1,0 +1,27 @@
+// src/scheduled.ts
+//
+// Cron handler. For now just a keep-alive: one trivial query so the Supabase
+// free tier doesn't pause the project after ~7 days idle. Fired by the cron in
+// wrangler.jsonc — deliberately not wired to /health, which stays cheap/public.
+import { sql } from 'drizzle-orm';
+import { getDb } from './db';
+import type { Bindings } from './types';
+
+export async function scheduled(
+  _event: ScheduledController,
+  env: Bindings,
+  ctx: ExecutionContext,
+): Promise<void> {
+  ctx.waitUntil(keepAlive(env));
+}
+
+async function keepAlive(env: Bindings): Promise<void> {
+  const db = getDb(env);
+  try {
+    await db.execute(sql`SELECT 1;`);
+  } catch (err) {
+    console.error('keep-alive query failed:', err);
+  } finally {
+    await db.$client.end();
+  }
+}

--- a/backend/src/scheduled.ts
+++ b/backend/src/scheduled.ts
@@ -7,11 +7,7 @@ import { sql } from 'drizzle-orm';
 import { getDb } from './db';
 import type { Bindings } from './types';
 
-export async function scheduled(
-  _event: ScheduledController,
-  env: Bindings,
-  ctx: ExecutionContext,
-): Promise<void> {
+export async function scheduled(_event: ScheduledController, env: Bindings, ctx: ExecutionContext): Promise<void> {
   ctx.waitUntil(keepAlive(env));
 }
 

--- a/backend/test/admin/routes.test.ts
+++ b/backend/test/admin/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import app from '../../src/index';
+import { app } from '../../src/index';
 
 const ADMIN_TOKEN = 'test-admin-token';
 

--- a/backend/test/cors.test.ts
+++ b/backend/test/cors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import app from '../src/index';
+import { app } from '../src/index';
 
 // Pins the CORS allow/deny contract so a future hono upgrade that changes the
 // origin-callback behavior fails here instead of silently in prod.

--- a/backend/test/index.test.ts
+++ b/backend/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import app from '../src/index';
+import { app } from '../src/index';
 
 describe('GET /', () => {
   it('returns the API name + version', async () => {

--- a/backend/test/r2/routes.test.ts
+++ b/backend/test/r2/routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import app from '../../src/index';
+import { app } from '../../src/index';
 
 // Fake R2 binding: get() returns a stand-in R2ObjectBody (just .text()) or null;
 // list() returns stand-in R2Objects (key + size).

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -3,6 +3,12 @@
   "name": "cccsolutions-backend",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-08",
+  // cron trigger for preventing supabase inactivity  
+  "triggers": {
+    "crons": [
+      "0 0 * * *"
+    ]
+  },
   // Explicit, not inherited: workers_dev defaults to true and preview_urls
   // defaults to workers_dev, so leaving these unset lets every deploy reassert
   // the defaults over a dashboard change. Both URLs are gated by edge
@@ -37,7 +43,6 @@
       "bucket_name": "cccsolutions",
     },
   ],
-
   // "d1_databases": [
   //   {
   //     "binding": "MY_DB",


### PR DESCRIPTION
## Description

Supabase pauses a free-tier project after ~7 days of inactivity. This adds a daily Cron Trigger that runs one trivial `select 1` to keep it awake.

Two deliberate choices: a **Cloudflare cron** rather than a GitHub Actions cron (GitHub auto-disables scheduled workflows after 60 days of repo inactivity, which would silently let the DB pause), and the cron touches the DB **directly** rather than by hitting `/health` (a public endpoint that queried the DB on every request would let scanners/monitors generate load). It reuses the Worker's existing `DATABASE_URL`, so no new secret and no external scheduler.

## Changes

- **`wrangler.jsonc`** — daily cron trigger (`0 0 * * *`). Daily (not every-6-days) keeps it safely under the 7-day threshold in every month; a `select 1` costs nothing.
- **`src/scheduled.ts`** (new) — the `scheduled()` handler + `keepAlive()`: one query, then closes the pooled connection. Intentionally not wired to `/health`.
- **`src/index.ts`** — the default export is now the Worker handler object (`{ fetch, scheduled } satisfies ExportedHandler<Bindings>`). `app` is exported by name so tests keep using Hono's `app.request()`.
- **`test/*`** — four files switched from the default import to `import { app }` (the default export is no longer the Hono app).

## Testing

- `tsc`, eslint, and vitest all pass locally.
- Manual: `bun run dev`, then `curl "http://localhost:8787/__scheduled?cron=0+0+*+*+*"` fires the handler on demand.
- The cron registers automatically on deploy (Workers Builds reads `wrangler.jsonc`); confirm under **Settings → Triggers → Cron Triggers** after merge.

## Linked issues

None — infra follow-up to the Supabase migration foundation (#179). Refs `docs/Roadmap40.md` (Phase 0).

## Checklist

- [x] I read CONTRIBUTING.md and gave the code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — `scheduled.ts` is a cron keep-alive; a unit test would only assert `select 1` runs, so left untested intentionally
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed (file-header comment explains the design)