### PR TITLE
fix(backend): enable nodejs_compat for the bundled postgres driver

### DIFF
--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -21,9 +21,7 @@
   "cache": {
     "enabled": true,
   },
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
+  "compatibility_flags": ["nodejs_compat"],
   // Public, non-secret config lives here so a deploy keeps it in sync (no dashboard
   // drift). SUPABASE_URL is the project's API gateway — not a secret (it also ships
   // in the frontend bundle). The real secrets — DATABASE_URL, SUPABASE_SECRET_KEY,


### PR DESCRIPTION
## Description

The keep-alive cron (#189) made the Worker bundle the `postgres` driver (via `getDb`), which imports `node:events`/`stream`/`buffer`. #189 merged without `nodejs_compat`, so the deploy to main failed (`No such module "node:events"`). Prod is still on the last good version; this re-enables the flag so the deploy — and the cron — go live.

## Changes

- `backend/wrangler.jsonc`: `"compatibility_flags": ["nodejs_compat"]`

## Testing

- `bunx wrangler deploy --dry-run` builds clean (no more `node:*` warnings).

## Linked issues

Refs #189.

## Checklist

- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] Code is formatted and matches the surrounding style